### PR TITLE
Skip empty PDFs during cron processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # fullforce-private-ai-agent
 Inhouse AI chatbot omgeving voor CS Rental, schaalbaar voor meerdere klanten.
+
+## PDF processing
+
+During the cron job (`pages/api/cron/process-unindexed-documents.ts`), PDFs are parsed to extract text. Some PDFs contain only images and yield no text after parsing. These PDFs are marked as unsupported and skipped; no OCR is currently performed.


### PR DESCRIPTION
## Summary
- handle PDFs with no extractable text by marking them as unsupported
- document that image-only PDFs are skipped and not OCR processed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing NEXT_PUBLIC_SUPABASE_URL environment variable)


------
https://chatgpt.com/codex/tasks/task_e_68a41cea11c0832ba67d70c826a6c30b