### PR TITLE
Use service role for chunk count in cron processor

### DIFF
--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -192,7 +192,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           skipExisting: false,
         });
 
-        const { count: chunkCount, error: countError } = await supabase
+        const { count: chunkCount, error: countError } = await supabaseAdmin
           .from('document_chunks')
           .select('*', { count: 'exact', head: true })
           .eq('metadata->id', document.id);


### PR DESCRIPTION
## Summary
- use `supabaseAdmin` when counting document chunks so service-role privileges return accurate counts

## Testing
- `npm test` *(fails: Missing script)*
- `npx ts-node --transpile-only -e "const handler=require('./pages/api/cron/process-unindexed-documents').default; const req={method:'GET', headers:{'x-api-key': process.env.CRON_API_KEY || 'default-key'}, query:{}}; const res={status:(code)=>({json:(obj)=>console.log('status', code, obj)})}; handler(req,res).then(()=>console.log('handler resolved')).catch(err=>console.error('handler error',err));"` *(fails: Cannot find module '/workspace/fullforce-private-ai-agent/lib/supabaseClient')*

------
https://chatgpt.com/codex/tasks/task_e_68a622f55bdc832bb3efed702599af2c