### PR TITLE
Use supabaseAdmin client for document processing pipeline and update IP whitelist

### DIFF
--- a/lib/middleware-helpers.ts
+++ b/lib/middleware-helpers.ts
@@ -47,6 +47,7 @@ export async function middleware(request: NextRequest) {
         '::1',
         '2a02:a46e:549e:0:e4c4:26b3:e601:6782',
         '84.86.144.131',
+        '86.80.188.129', // stationslaan
         '185.56.55.239',
         '45.147.87.232',
         // Add more from env

--- a/lib/rag/documentProcessor.ts
+++ b/lib/rag/documentProcessor.ts
@@ -1,11 +1,11 @@
-import { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { DocumentMetadata, TextChunk, ProcessingOptions } from './types';
 
 export class DocumentProcessor {
-  private supabase: SupabaseClient;
-  
-  constructor(supabaseClient: SupabaseClient) {
-    this.supabase = supabaseClient;
+  private supabaseAdmin: SupabaseClient;
+
+  constructor(supabaseAdmin: SupabaseClient) {
+    this.supabaseAdmin = supabaseAdmin;
   }
 
   async processDocument(metadata: DocumentMetadata, options: ProcessingOptions): Promise<TextChunk[]> {
@@ -22,7 +22,7 @@ export class DocumentProcessor {
       } else {
         // Fall back to downloading and extracting text (legacy method)
         console.log(`📥 Downloading document from ${metadata.storage_path}...`);
-        const { data, error } = await this.supabase
+        const { data, error } = await this.supabaseAdmin
           .storage
           .from('company-docs')
           .download(metadata.storage_path);

--- a/lib/rag/pipeline.ts
+++ b/lib/rag/pipeline.ts
@@ -1,4 +1,4 @@
-import { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { DocumentProcessor } from './documentProcessor';
 import { EmbeddingGenerator } from './embeddingGenerator';
 import { VectorStore } from './vectorStore';
@@ -6,16 +6,16 @@ import { DocumentMetadata, ProcessingOptions } from './types';
 import { RAG_CONFIG } from '@/lib/rag/config';
 
 export class RAGPipeline {
-  private supabase: SupabaseClient;
+  private supabaseAdmin: SupabaseClient;
   private documentProcessor: DocumentProcessor;
   private embeddingGenerator: EmbeddingGenerator;
   private vectorStore: VectorStore;
 
-  constructor(supabaseClient: SupabaseClient, openAIKey: string) {
-    this.supabase = supabaseClient;
-    this.documentProcessor = new DocumentProcessor(supabaseClient);
+  constructor(supabaseAdmin: SupabaseClient, openAIKey: string) {
+    this.supabaseAdmin = supabaseAdmin;
+    this.documentProcessor = new DocumentProcessor(supabaseAdmin);
     this.embeddingGenerator = new EmbeddingGenerator(openAIKey);
-    this.vectorStore = new VectorStore(supabaseClient);
+    this.vectorStore = new VectorStore(supabaseAdmin);
   }
 
   async processDocument(metadata: DocumentMetadata, options: ProcessingOptions): Promise<void> {
@@ -55,7 +55,7 @@ export class RAGPipeline {
 
   private async updateDocumentStatus(documentId: string, success: boolean): Promise<void> {
     try {
-      const { error } = await this.supabase
+      const { error } = await this.supabaseAdmin
         .from('documents_metadata')
         .update({ 
           processed: success, 

--- a/lib/rag/vectorStore.ts
+++ b/lib/rag/vectorStore.ts
@@ -1,11 +1,11 @@
-import { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { TextChunk } from './types';
 
 export class VectorStore {
-  private supabase: SupabaseClient;
+  private supabaseAdmin: SupabaseClient;
 
-  constructor(supabaseClient: SupabaseClient) {
-    this.supabase = supabaseClient;
+  constructor(supabaseAdmin: SupabaseClient) {
+    this.supabaseAdmin = supabaseAdmin;
   }
 
   async storeChunks(chunks: TextChunk[]): Promise<void> {
@@ -18,7 +18,7 @@ export class VectorStore {
       }
 
       try {
-        const { error } = await this.supabase
+        const { error } = await this.supabaseAdmin
           .from('document_chunks')
           .insert({
             content: chunk.content,
@@ -95,12 +95,12 @@ export class VectorStore {
           LIMIT :match_count
         `;
         
-        const result = await this.supabase.rpc('sql', { query, params: filterParams });
+        const result = await this.supabaseAdmin.rpc('sql', { query, params: filterParams });
         data = result.data;
         error = result.error;
       } else {
         // Use the standard match_documents function when no filters
-        const result = await this.supabase.rpc('match_documents', {
+        const result = await this.supabaseAdmin.rpc('match_documents', {
           query_embedding: queryEmbedding,
           match_threshold: threshold,
           match_count: limit
@@ -133,7 +133,7 @@ export class VectorStore {
       console.log(`🔍 Falling back to text search with limit ${limit}${filter ? ' and filters' : ''}...`);
       
       // Start building the query
-      let queryBuilder = this.supabase
+      let queryBuilder = this.supabaseAdmin
         .from('document_chunks')
         .select('*');
       
@@ -177,7 +177,7 @@ export class VectorStore {
     try {
       console.log(`🗑️ Deleting chunks for document ${documentId}...`);
       
-      const { error } = await this.supabase
+      const { error } = await this.supabaseAdmin
         .from('document_chunks')
         .delete()
         .eq('metadata->id', documentId);

--- a/middleware.ts
+++ b/middleware.ts
@@ -68,6 +68,7 @@ export async function middleware(req: NextRequest) {
         '::1',
         '84.86.144.131',
         '213.124.97.74', // abc
+        '86.80.188.129', // stationslaan
         '185.56.55.239',
         '45.147.87.232',
         '2a02:a46e:549e:0:e4c4:26b3:e601:6782',

--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -185,7 +185,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         document.extractedText = extractedText;
 
-        const pipeline = new RAGPipeline(supabase, openaiApiKey);
+        const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
         await pipeline.processDocument(document, {
           chunkSize: RAG_CONFIG.chunkSize,
           chunkOverlap: RAG_CONFIG.chunkOverlap,

--- a/pages/api/process-document.ts
+++ b/pages/api/process-document.ts
@@ -174,8 +174,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     console.log(`📊 Extracted ${extractedText.length} characters of text`);
 
-    // Create RAG pipeline
-    const pipeline = new RAGPipeline(supabase, openaiApiKey);
+    // Create RAG pipeline with admin client for service-level operations
+    const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
 
     // Process document with extracted text and track chunk count
     console.log('🧠 Starting RAG pipeline processing...');


### PR DESCRIPTION
## Summary
- Instantiate RAG pipeline with `supabaseAdmin` in document processing API routes
- Propagate admin client through RAG pipeline, document processor and vector store constructors
- Use admin client for service-level actions like chunk storage and status updates
- Add `86.80.188.129` (Stationslaan) to middleware IP allowlists

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `node scripts/rag-create-test-docs.js` *(fails: Missing Supabase environment variables)*
- `node scripts/process-document.js dummy-id` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a62501b2bc832bbebb336bb85050d0