### PR TITLE
chore: mask sensitive cron log output

### DIFF
--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -19,8 +19,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   // 🧪 Debug info
-  console.log('🔐 Loaded API_KEY:', API_KEY);
-  console.log('🔐 Loaded CRON_BYPASS_KEY:', CRON_BYPASS_KEY);
+  console.log('🔐 API key loaded');
+  console.log('🔐 CRON bypass key loaded');
   console.log('🔎 Request headers:', req.headers);
 
   const apiKey = req.headers['x-api-key'] || req.query.key;


### PR DESCRIPTION
## Summary
- avoid logging actual CRON_API_KEY and CRON_BYPASS_KEY values

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6290c9f34832b9e705219852715c3