### PR TITLE
require cron env keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # fullforce-private-ai-agent
 Inhouse AI chatbot omgeving voor CS Rental, schaalbaar voor meerdere klanten.
+
+## Omgevingsvariabelen
+
+Voor het cron-endpoint moeten de volgende variabelen ingesteld zijn:
+
+- `CRON_API_KEY`
+- `CRON_BYPASS_KEY`
+
+Als een van deze ontbreekt, wordt er een fout gelogd en stopt de server of geeft het endpoint een 500-fout terug.

--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -10,8 +10,19 @@ import Tesseract from 'tesseract.js';
 import JSZip from 'jszip';
 
 // ✅ Veilig opgehaalde environment variables
-const API_KEY = process.env.CRON_API_KEY || 'default-key';
-const CRON_BYPASS_KEY = process.env.CRON_BYPASS_KEY || 'fallback-key';
+const API_KEY = process.env.CRON_API_KEY;
+if (!API_KEY) {
+  const message = 'CRON_API_KEY environment variable is missing';
+  console.error(message);
+  throw new Error(message);
+}
+
+const CRON_BYPASS_KEY = process.env.CRON_BYPASS_KEY;
+if (!CRON_BYPASS_KEY) {
+  const message = 'CRON_BYPASS_KEY environment variable is missing';
+  console.error(message);
+  throw new Error(message);
+}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {


### PR DESCRIPTION
## Summary
- ensure cron process requires CRON_API_KEY and CRON_BYPASS_KEY
- document required env vars for cron endpoint

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a62a2cb698832b94825527fe3397ce