### PR TITLE
Limit cron document processing

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Call RAG CRON endpoint
         run: |
-          curl -X GET "https://fullforce-private-ai-agent.vercel.app/api/cron/process-unindexed-documents?key=${{ secrets.CRON_API_KEY }}" \
+          curl -X GET "https://fullforce-private-ai-agent.vercel.app/api/cron/process-unindexed-documents?limit=2&key=${{ secrets.CRON_API_KEY }}" \
                -H "x-cron-key: ${{ secrets.CRON_BYPASS_KEY }}" \
                -H "x-api-key: ${{ secrets.CRON_API_KEY }}"


### PR DESCRIPTION
## Summary
- limit RAG cron endpoint to process only two documents per run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac537f88e0832bb555acc09a5fa63e