### PR TITLE
Restrict cron workflow to main branch

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   trigger-cron:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Call RAG CRON endpoint


### PR DESCRIPTION
## Summary
- run cron workflow only when triggered from main branch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac548bacc8832b9e950d2f762f6cf0