### PR TITLE
Queue-based document processing

### DIFF
--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -1,13 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { supabase } from '../../../lib/supabaseClient';
 import { supabaseAdmin } from '../../../lib/supabaseAdmin';
-import { RAGPipeline } from '../../../lib/rag/pipeline';
-import { openaiApiKey, RAG_CONFIG } from '../../../lib/rag/config';
-import pdfParse from 'pdf-parse';
-import mammoth from 'mammoth';
-import path from 'path';
-import Tesseract from 'tesseract.js';
-import JSZip from 'jszip';
 
 // ✅ Veilig opgehaalde environment variables
 const API_KEY = process.env.CRON_API_KEY;
@@ -47,13 +40,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    console.log('🔄 CRON job started: processing unindexed documents');
+    console.log('🔄 CRON job started: queuing unindexed documents');
 
     const limit = parseInt(req.query.limit as string) || 10;
 
     const { data: documents, error: fetchError } = await supabase
       .from('documents_metadata')
-      .select('*')
+      .select('id, filename')
       .eq('ready_for_indexing', true)
       .eq('processed', false)
       .order('last_updated', { ascending: true })
@@ -65,186 +58,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     if (!documents || documents.length === 0) {
-      console.log('✅ No documents to process');
-      return res.status(200).json({ message: 'No documents to process' });
+      console.log('✅ No documents to queue');
+      return res.status(200).json({ message: 'No documents to queue' });
     }
 
-    const results = [];
-
-    const SUPPORTED_MIME_TYPES = [
-      'application/pdf',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'text/plain',
-      'text/markdown',
-      'application/msword',
-      'application/vnd.oasis.opendocument.text',
-      'text/csv',
-      'text/rtf',
-    ];
-
-    const SUPPORTED_EXTENSIONS = [
-      '.pdf',
-      '.docx',
-      '.txt',
-      '.md',
-      '.doc',
-      '.odt',
-      '.csv',
-      '.rtf',
-    ];
-
+    let enqueued = 0;
     for (const document of documents) {
-      try {
-        console.log(`[CRON] 🔧 Processing: ${document.filename}`);
+      const { error: insertError } = await supabaseAdmin
+        .from('document_processing_queue')
+        .insert({ document_id: document.id });
 
-        const extension = path.extname(document.filename || '').toLowerCase();
-        const mimeType = (document.mime_type || '').toLowerCase();
-        const isSupported =
-          SUPPORTED_MIME_TYPES.includes(mimeType) || SUPPORTED_EXTENSIONS.includes(extension);
-
-        if (!isSupported) {
-          const message = `Unsupported file type: ${mimeType || extension}`;
-          console.warn(`[CRON] ⚠️ Skipping ${document.filename}: ${message}`);
-
-          await supabaseAdmin
-            .from('documents_metadata')
-            .update({
-              processed: true,
-              processed_at: new Date().toISOString(),
-              chunk_count: 0,
-              last_error: message,
-            })
-            .eq('id', document.id);
-
-          results.push({ id: document.id, filename: document.filename, success: false, error: message });
-          continue;
-        }
-
-        const { data: fileData, error: downloadError } = await supabase
-          .storage
-          .from('company-docs')
-          .download(document.storage_path);
-
-        if (downloadError) throw new Error(`Failed to download: ${downloadError.message}`);
-
-        const arrayBuffer = await fileData.arrayBuffer();
-        let extractedText = '';
-
-        if (document.mime_type === 'application/pdf' || document.filename.endsWith('.pdf')) {
-          const buffer = Buffer.from(arrayBuffer);
-          const pdfData = await pdfParse(buffer);
-          extractedText = pdfData.text;
-          if (!extractedText.trim()) {
-            console.log(`[CRON] 🖼️ ${document.filename} appears to be image-only, running OCR`);
-            try {
-              const ocrResult = await Tesseract.recognize(buffer, 'eng');
-              extractedText = ocrResult.data.text;
-            } catch (ocrErr) {
-              console.error(`[CRON] ⚠️ OCR failed for ${document.filename}:`, ocrErr);
-            }
-          }
-        } else if (
-          document.mime_type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
-          document.filename.endsWith('.docx')
-        ) {
-          const buffer = Buffer.from(arrayBuffer);
-          const docxData = await mammoth.extractRawText({
-            buffer,
-          });
-          extractedText = docxData.value;
-          if (!extractedText.trim()) {
-            console.log(`[CRON] 🖼️ ${document.filename} contains images only, attempting OCR`);
-            try {
-              const zip = await JSZip.loadAsync(buffer);
-              const media = zip.folder('word/media');
-              if (media) {
-                let ocrText = '';
-                const imagePromises: Promise<Buffer>[] = [];
-                media.forEach((relativePath, file) => {
-                  imagePromises.push(file.async('nodebuffer'));
-                });
-                const imageBuffers = await Promise.all(imagePromises);
-                for (const img of imageBuffers) {
-                  const ocrResult = await Tesseract.recognize(img, 'eng');
-                  ocrText += ocrResult.data.text + '\n';
-                }
-                extractedText = ocrText;
-              }
-            } catch (ocrErr) {
-              console.error(`[CRON] ⚠️ OCR failed for ${document.filename}:`, ocrErr);
-            }
-          }
-        } else {
-          extractedText = await fileData.text();
-        }
-
-        if (!extractedText || extractedText.trim().length === 0) {
-          const message = 'No text found (even with OCR)';
-          await supabaseAdmin
-            .from('documents_metadata')
-            .update({
-              processed: true,
-              processed_at: new Date().toISOString(),
-              chunk_count: 0,
-              last_error: message,
-            })
-            .eq('id', document.id);
-
-          results.push({ id: document.id, filename: document.filename, success: false, error: message });
-          continue;
-        }
-
-        document.extractedText = extractedText;
-
-        const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
-        await pipeline.processDocument(document, {
-          chunkSize: RAG_CONFIG.chunkSize,
-          chunkOverlap: RAG_CONFIG.chunkOverlap,
-          skipExisting: false,
-        });
-
-        const { count: chunkCount, error: countError } = await supabaseAdmin
-          .from('document_chunks')
-          .select('*', { count: 'exact', head: true })
-          .eq('metadata->id', document.id);
-
-        if (countError) {
-          console.error('⚠️ Error counting chunks:', countError.message);
-        }
-
-        await supabaseAdmin
-          .from('documents_metadata')
-          .update({
-            processed: true,
-            processed_at: new Date().toISOString(),
-            chunk_count: chunkCount || 0,
-            last_error: null,
-          })
-          .eq('id', document.id);
-
-        console.log(`[CRON] ✅ ${document.filename} → ${chunkCount || 0} chunks`);
-
-        results.push({ id: document.id, filename: document.filename, success: true, chunkCount: chunkCount || 0 });
-      } catch (error) {
-        const err = error as Error;
-        console.error(`[CRON] ❌ Error processing ${document.filename}:`, err.message);
-
-        await supabaseAdmin
-          .from('documents_metadata')
-          .update({
-            last_error: `Processing failed: ${err.message}`,
-          })
-          .eq('id', document.id);
-
-        results.push({ id: document.id, filename: document.filename, success: false, error: err.message });
+      if (insertError) {
+        console.error(`[CRON] ❌ Failed to enqueue ${document.id}:`, insertError.message);
+      } else {
+        enqueued += 1;
+        console.log(`[CRON] 📨 Enqueued document ${document.id}`);
       }
     }
 
     return res.status(200).json({
-      message: `Processed ${results.length} document(s)`,
-      processed: results.filter(r => r.success).length,
-      failed: results.filter(r => !r.success).length,
-      results,
+      message: `Enqueued ${enqueued} document(s)`
     });
   } catch (error) {
     const err = error as Error;

--- a/pages/api/worker/process-queued-document.ts
+++ b/pages/api/worker/process-queued-document.ts
@@ -1,0 +1,213 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '../../../lib/supabaseClient';
+import { supabaseAdmin } from '../../../lib/supabaseAdmin';
+import { RAGPipeline } from '../../../lib/rag/pipeline';
+import { openaiApiKey, RAG_CONFIG } from '../../../lib/rag/config';
+import pdfParse from 'pdf-parse';
+import mammoth from 'mammoth';
+import Tesseract from 'tesseract.js';
+import JSZip from 'jszip';
+import path from 'path';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // Fetch next item from the queue
+    const { data: task, error: taskError } = await supabaseAdmin
+      .from('document_processing_queue')
+      .select('*')
+      .eq('processed', false)
+      .order('created_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (taskError) {
+      console.error('❌ Error fetching queue:', taskError);
+      return res.status(500).json({ error: 'Failed to fetch queue' });
+    }
+
+    if (!task) {
+      return res.status(200).json({ message: 'No queued documents' });
+    }
+
+    const { data: document, error: docError } = await supabaseAdmin
+      .from('documents_metadata')
+      .select('*')
+      .eq('id', task.document_id)
+      .maybeSingle();
+
+    if (docError || !document) {
+      console.error('❌ Failed to load document metadata:', docError);
+      return res.status(500).json({ error: 'Document not found' });
+    }
+
+    const SUPPORTED_MIME_TYPES = [
+      'application/pdf',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'text/plain',
+      'text/markdown',
+      'application/msword',
+      'application/vnd.oasis.opendocument.text',
+      'text/csv',
+      'text/rtf',
+    ];
+
+    const SUPPORTED_EXTENSIONS = [
+      '.pdf',
+      '.docx',
+      '.txt',
+      '.md',
+      '.doc',
+      '.odt',
+      '.csv',
+      '.rtf',
+    ];
+
+    const extension = path.extname(document.filename || '').toLowerCase();
+    const mimeType = (document.mime_type || '').toLowerCase();
+    const isSupported =
+      SUPPORTED_MIME_TYPES.includes(mimeType) || SUPPORTED_EXTENSIONS.includes(extension);
+
+    if (!isSupported) {
+      const message = `Unsupported file type: ${mimeType || extension}`;
+      console.warn(`[WORKER] ⚠️ Skipping ${document.filename}: ${message}`);
+
+      await supabaseAdmin
+        .from('documents_metadata')
+        .update({
+          processed: true,
+          processed_at: new Date().toISOString(),
+          chunk_count: 0,
+          last_error: message,
+        })
+        .eq('id', document.id);
+
+      await supabaseAdmin
+        .from('document_processing_queue')
+        .update({ processed: true, processed_at: new Date().toISOString() })
+        .eq('id', task.id);
+
+      return res.status(200).json({ message: 'Skipped unsupported document', id: document.id });
+    }
+
+    const { data: fileData, error: downloadError } = await supabase
+      .storage
+      .from('company-docs')
+      .download(document.storage_path);
+
+    if (downloadError) throw new Error(`Failed to download: ${downloadError.message}`);
+
+    const arrayBuffer = await fileData.arrayBuffer();
+    let extractedText = '';
+
+    if (document.mime_type === 'application/pdf' || document.filename.endsWith('.pdf')) {
+      const buffer = Buffer.from(arrayBuffer);
+      const pdfData = await pdfParse(buffer);
+      extractedText = pdfData.text;
+      if (!extractedText.trim()) {
+        console.log(`[WORKER] 🖼️ ${document.filename} appears to be image-only, running OCR`);
+        try {
+          const ocrResult = await Tesseract.recognize(buffer, 'eng');
+          extractedText = ocrResult.data.text;
+        } catch (ocrErr) {
+          console.error(`[WORKER] ⚠️ OCR failed for ${document.filename}:`, ocrErr);
+        }
+      }
+    } else if (
+      document.mime_type === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+      document.filename.endsWith('.docx')
+    ) {
+      const buffer = Buffer.from(arrayBuffer);
+      const docxData = await mammoth.extractRawText({ buffer });
+      extractedText = docxData.value;
+      if (!extractedText.trim()) {
+        console.log(`[WORKER] 🖼️ ${document.filename} contains images only, attempting OCR`);
+        try {
+          const zip = await JSZip.loadAsync(buffer);
+          const media = zip.folder('word/media');
+          if (media) {
+            let ocrText = '';
+            const imagePromises: Promise<Buffer>[] = [];
+            media.forEach((relativePath, file) => {
+              imagePromises.push(file.async('nodebuffer'));
+            });
+            const imageBuffers = await Promise.all(imagePromises);
+            for (const img of imageBuffers) {
+              const ocrResult = await Tesseract.recognize(img, 'eng');
+              ocrText += ocrResult.data.text + '\n';
+            }
+            extractedText = ocrText;
+          }
+        } catch (ocrErr) {
+          console.error(`[WORKER] ⚠️ OCR failed for ${document.filename}:`, ocrErr);
+        }
+      }
+    } else {
+      extractedText = await fileData.text();
+    }
+
+    if (!extractedText || extractedText.trim().length === 0) {
+      const message = 'No text found (even with OCR)';
+      await supabaseAdmin
+        .from('documents_metadata')
+        .update({
+          processed: true,
+          processed_at: new Date().toISOString(),
+          chunk_count: 0,
+          last_error: message,
+        })
+        .eq('id', document.id);
+
+      await supabaseAdmin
+        .from('document_processing_queue')
+        .update({ processed: true, processed_at: new Date().toISOString() })
+        .eq('id', task.id);
+
+      return res.status(200).json({ message: 'No text extracted', id: document.id });
+    }
+
+    document.extractedText = extractedText;
+
+    const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
+    await pipeline.processDocument(document, {
+      chunkSize: RAG_CONFIG.chunkSize,
+      chunkOverlap: RAG_CONFIG.chunkOverlap,
+      skipExisting: false,
+    });
+
+    const { count: chunkCount, error: countError } = await supabaseAdmin
+      .from('document_chunks')
+      .select('*', { count: 'exact', head: true })
+      .eq('metadata->id', document.id);
+
+    if (countError) {
+      console.error('⚠️ Error counting chunks:', countError.message);
+    }
+
+    await supabaseAdmin
+      .from('documents_metadata')
+      .update({
+        processed: true,
+        processed_at: new Date().toISOString(),
+        chunk_count: chunkCount || 0,
+        last_error: null,
+      })
+      .eq('id', document.id);
+
+    await supabaseAdmin
+      .from('document_processing_queue')
+      .update({ processed: true, processed_at: new Date().toISOString() })
+      .eq('id', task.id);
+
+    console.log(`[WORKER] ✅ ${document.filename} → ${chunkCount || 0} chunks`);
+
+    return res.status(200).json({ message: 'Processed document', id: document.id, chunkCount: chunkCount || 0 });
+  } catch (error) {
+    const err = error as Error;
+    console.error('❌ Worker failed:', err.message);
+    return res.status(500).json({ error: 'Unexpected error', details: err.message });
+  }
+}

--- a/supabase/migrations/20250705110000_add_document_processing_queue.sql
+++ b/supabase/migrations/20250705110000_add_document_processing_queue.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS document_processing_queue (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  document_id UUID NOT NULL REFERENCES documents_metadata(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  processed BOOLEAN DEFAULT FALSE,
+  processed_at TIMESTAMPTZ
+);
+
+-- Optional index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_document_processing_queue_processed ON document_processing_queue(processed, created_at);


### PR DESCRIPTION
## Summary
- add queue table for background processing
- refactor cron route to enqueue pending documents
- add worker API to process queued documents with OCR and chunking

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac567d2228832b9b3931c37d024370