### PR TITLE
Limit cron workflow to one document per run

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
       - name: Call RAG CRON endpoint
         run: |
-          curl -X GET "https://fullforce-private-ai-agent.vercel.app/api/cron/process-unindexed-documents?key=${{ secrets.CRON_API_KEY }}" \
+          curl -X GET "https://fullforce-private-ai-agent.vercel.app/api/cron/process-unindexed-documents?limit=1&key=${{ secrets.CRON_API_KEY }}" \
                -H "x-cron-key: ${{ secrets.CRON_BYPASS_KEY }}" \
                -H "x-api-key: ${{ secrets.CRON_API_KEY }}"


### PR DESCRIPTION
## Summary
- constrain cron workflow to process a single unindexed document per invocation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b08cbc4832bb840efec2dad7733