### PR TITLE
feat: add CRON document limit env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Voor het cron-endpoint moeten de volgende variabelen ingesteld zijn:
 
 - `CRON_API_KEY`
 - `CRON_BYPASS_KEY`
+- `CRON_DOCUMENT_LIMIT` – maximaal aantal documenten dat per run wordt verwerkt (standaard 1)
 
 Als een van deze ontbreekt, wordt er een fout gelogd en stopt de server of geeft het endpoint een 500-fout terug.
 

--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -49,7 +49,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   try {
     console.log('🔄 CRON job started: processing unindexed documents');
 
-    const limit = parseInt(req.query.limit as string) || 10;
+    const limit =
+      parseInt(req.query.limit as string) ||
+      parseInt(process.env.CRON_DOCUMENT_LIMIT || '1');
 
     const { data: documents, error: fetchError } = await supabase
       .from('documents_metadata')


### PR DESCRIPTION
## Summary
- allow CRON document processing limit to be configured via `CRON_DOCUMENT_LIMIT`
- document CRON document limit env var in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac5c329dc8832b981530baac16c784