### PR TITLE
feat: improve chat session handling

### DIFF
--- a/pages/api/admin/chat-sessions.ts
+++ b/pages/api/admin/chat-sessions.ts
@@ -1,0 +1,68 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { supabase } from '../../../lib/supabaseClient';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method !== 'GET') {
+      return res.status(405).json({ error: 'Method not allowed' });
+    }
+
+    // Verify admin authentication
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'No authorization header' });
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user } } = await supabase.auth.getUser(token);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+
+    // Check admin role
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('role')
+      .eq('id', user.id)
+      .single();
+    if (!profile || profile.role !== 'admin') {
+      return res.status(403).json({ error: 'Admin access required' });
+    }
+
+    const { data: sessions, error } = await supabase
+      .from('chat_sessions')
+      .select('id, title, mode, updated_at, archived, profiles!inner(email)')
+      .order('updated_at', { ascending: false });
+
+    if (error || !sessions) {
+      return res.status(500).json({ error: 'Failed to fetch sessions' });
+    }
+
+    const sessionsWithFeedback = await Promise.all(
+      sessions.map(async (session: any) => {
+        const { data: feedback } = await supabase
+          .from('message_feedback')
+          .select('message_id, created_at')
+          .eq('session_id', session.id)
+          .eq('feedback_type', 'thumbs_down')
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        return {
+          id: session.id,
+          title: session.title,
+          mode: session.mode,
+          updated_at: session.updated_at,
+          archived: session.archived,
+          user_email: session.profiles.email,
+          last_thumbs_down: feedback || null
+        };
+      })
+    );
+
+    return res.status(200).json(sessionsWithFeedback);
+  } catch (error) {
+    console.error('Error fetching admin chat sessions:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/pages/api/generate-title.ts
+++ b/pages/api/generate-title.ts
@@ -1,0 +1,37 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { OpenAI } from 'openai';
+import { openaiApiKey } from '../../lib/rag/config';
+
+const openai = new OpenAI({ apiKey: openaiApiKey });
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { message } = req.body;
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+
+  try {
+    const completion = await openai.chat.completions.create({
+      model: process.env.OPENAI_MODEL_SIMPLE || 'gpt-4-turbo',
+      messages: [
+        { role: 'system', content: 'Genereer een korte titel (maximaal 6 woorden) voor het volgende chatgesprek.' },
+        { role: 'user', content: message }
+      ],
+      max_tokens: 20,
+      temperature: 0.7
+    });
+
+    const title = completion.choices?.[0]?.message?.content?.trim();
+    if (!title) {
+      return res.status(500).json({ error: 'Failed to generate title' });
+    }
+    return res.status(200).json({ title });
+  } catch (error) {
+    console.error('Error generating title:', error);
+    return res.status(500).json({ error: 'Failed to generate title' });
+  }
+}

--- a/supabase/migrations/20250707130000_add_archived_to_chat_sessions.sql
+++ b/supabase/migrations/20250707130000_add_archived_to_chat_sessions.sql
@@ -1,0 +1,3 @@
+-- Add archived column to chat_sessions for soft deletes
+ALTER TABLE chat_sessions ADD COLUMN IF NOT EXISTS archived boolean NOT NULL DEFAULT false;
+CREATE INDEX IF NOT EXISTS chat_sessions_archived_idx ON chat_sessions(archived);


### PR DESCRIPTION
## Summary
- generate session titles using OpenAI instead of simple splitting
- support archived chat sessions with restore functionality
- add admin chat session overview with negative feedback info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6dee591fc832b8c81845ea9cbe409