### PR TITLE
Expose chunk count and retry logging for RAG cron

### DIFF
--- a/.github/workflows/trigger-cron.yml
+++ b/.github/workflows/trigger-cron.yml
@@ -22,10 +22,20 @@ jobs:
             echo "❌ Found deprecated ?key= usage in workflows"; exit 1;
           fi
           echo "✅ No query-key usage found"
+      - name: Check required secrets
+        run: |
+          set -euo pipefail
+          [ -n "${{ secrets.OPENAI_API_KEY }}" ] || (echo "❌ OPENAI_API_KEY missing"; exit 1)
+          [ -n "${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" ] || (echo "❌ SUPABASE_SERVICE_ROLE_KEY missing"; exit 1)
+          [ -n "${{ secrets.CRON_API_KEY }}" ] || (echo "❌ CRON_API_KEY missing"; exit 1)
+          echo "✅ Secrets present"
       - name: Trigger cron endpoint (header auth, limit=1)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: |
           set -euo pipefail
           curl -sS -f --retry 3 --retry-delay 5 \
-            -H "X-Cron-Key: ${{ secrets.CRON_BYPASS_KEY }}" \
+            -H "x-api-key: ${{ secrets.CRON_API_KEY }}" \
             "https://fullforce-private-ai-agent.vercel.app/api/cron/process-unindexed-documents?limit=1"
 

--- a/tests/rag/pipeline.test.ts
+++ b/tests/rag/pipeline.test.ts
@@ -50,8 +50,12 @@ describe('RAGPipeline', () => {
     storeChunksMock.mockResolvedValue(undefined);
 
     const pipeline = new RAGPipeline(supabase, 'key');
-    await pipeline.processDocument({ id: 'doc1', filename: 'f' } as any, {} as any);
+    const count = await pipeline.processDocument(
+      { id: 'doc1', filename: 'f' } as any,
+      {} as any
+    );
 
+    expect(count).toBe(1);
     expect(processDocumentMock).toHaveBeenCalled();
     expect(generateEmbeddingsMock).toHaveBeenCalled();
     expect(storeChunksMock).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Have RAG pipeline return stored chunk count and persist chunk_count in documents_metadata
- Improve cron handler with detailed per-document logging, chunk count usage, and OpenAI retry tracking
- Ensure scheduled workflow triggers cron with x-api-key header and required secrets
- Add cron validation in check-rag-status script

## Testing
- `npm test`
- `node scripts/check-rag-status.js` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e0fffbb0832b945f992c37b07b1f