### PR TITLE
feat: update theme colors and enlarge logo

### DIFF
--- a/components/ChatHeader.tsx
+++ b/components/ChatHeader.tsx
@@ -20,8 +20,8 @@ export default function ChatHeader({ mode }: ChatHeaderProps) {
           <Image
             src="/csrental-logo.svg"
             alt="CSRental logo"
-            width={32}
-            height={32}
+            width={96}
+            height={96}
             className="mr-3"
           />
           <div>
@@ -31,7 +31,7 @@ export default function ChatHeader({ mode }: ChatHeaderProps) {
         </div>
         <button
           onClick={() => router.push('/select-assistant')}
-          className="px-4 py-2 rounded-lg bg-secondary text-white hover:bg-secondary/90 transition-colors duration-200"
+          className="px-4 py-2 rounded-lg bg-secondary text-gray-900 hover:bg-secondary/90 transition-colors duration-200"
         >
           Switch Assistant
         </button>

--- a/components/ChatSidebar.tsx
+++ b/components/ChatSidebar.tsx
@@ -190,7 +190,7 @@ export default function ChatSidebar({
 
           <button
             onClick={onNewChat}
-            className="w-full bg-secondary hover:bg-secondary/90 text-white rounded-lg py-2 px-3 text-sm font-medium transition-colors flex items-center justify-center shadow"
+            className="w-full bg-secondary hover:bg-secondary/90 text-gray-900 rounded-lg py-2 px-3 text-sm font-medium transition-colors flex items-center justify-center shadow"
           >
             <span className="mr-2">+</span>
             New Chat
@@ -223,7 +223,7 @@ export default function ChatSidebar({
                   className={`
                     group relative p-3 rounded-lg cursor-pointer transition-colors mb-1 shadow-sm
                     ${currentSessionId === session.id
-                      ? 'bg-secondary text-white'
+                      ? 'bg-secondary text-gray-900'
                       : 'hover:bg-primary/60 text-white/90'
                     }
                   `}

--- a/pages/admin/create-diego-complete.tsx
+++ b/pages/admin/create-diego-complete.tsx
@@ -158,7 +158,7 @@ CSrental AI Team`;
                   <div className="bg-white p-3 rounded border">
                     <p><strong>Email:</strong> {result.loginCredentials.email}</p>
                     <p><strong>Temporary Password:</strong> <code className="bg-gray-100 px-1 rounded">{result.loginCredentials.password}</code></p>
-                    <p className="text-xs text-orange-600 mt-1">⚠️ {result.loginCredentials.note}</p>
+                    <p className="text-xs text-primary mt-1">⚠️ {result.loginCredentials.note}</p>
                   </div>
                   <div className="flex space-x-2 mt-2">
                     <button

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -213,7 +213,7 @@ export default function AdminDashboard() {
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <div className="flex items-center">
-            <Image src="/csrental-logo.svg" alt="CSRental logo" width={32} height={32} className="mr-3" />
+            <Image src="/csrental-logo.svg" alt="CSRental logo" width={96} height={96} className="mr-3" />
             <div>
               <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
               <p className="text-gray-600 mt-1">Beheer gebruikers en documenten</p>

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -76,7 +76,7 @@ export default function ChatPage() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
               </button>
-              <Image src="/csrental-logo.svg" alt="CSRental logo" width={32} height={32} className="mr-2" />
+              <Image src="/csrental-logo.svg" alt="CSRental logo" width={96} height={96} className="mr-2" />
               <div>
                 <h1 className="text-2xl font-bold">{validMode === 'technical' ? 'CeeS' : 'ChriS'}</h1>
                 <p className="text-white/80 text-sm mt-1">
@@ -90,7 +90,7 @@ export default function ChatPage() {
               <ThemeToggle />
               <button
                 onClick={() => router.push('/select-assistant')}
-                className="px-4 py-2 rounded-lg bg-secondary text-white hover:bg-secondary/90 transition-colors duration-200"
+                className="px-4 py-2 rounded-lg bg-secondary text-gray-900 hover:bg-secondary/90 transition-colors duration-200"
               >
                 Switch Assistant
               </button>

--- a/pages/emergency-access.tsx
+++ b/pages/emergency-access.tsx
@@ -45,7 +45,7 @@ export default function EmergencyAccess() {
 
   if (success) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-red-500 via-orange-500 to-yellow-500 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-to-br from-red-500 via-secondary to-yellow-500 flex items-center justify-center p-4">
         <div className="bg-white rounded-xl shadow-2xl p-8 max-w-md w-full text-center">
           <div className="text-6xl mb-4">✅</div>
           <h1 className="text-2xl font-bold text-green-600 mb-4">
@@ -81,7 +81,7 @@ export default function EmergencyAccess() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-red-500 via-orange-500 to-yellow-500 flex items-center justify-center p-4">
+    <div className="min-h-screen bg-gradient-to-br from-red-500 via-secondary to-yellow-500 flex items-center justify-center p-4">
       <div className="bg-white rounded-xl shadow-2xl p-8 max-w-md w-full">
         <div className="text-center mb-8">
           <div className="text-6xl mb-4">🚨</div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -27,6 +27,6 @@
   }
 
   button {
-    @apply bg-secondary text-white rounded-lg hover:bg-secondary/90 transition-colors;
+    @apply bg-secondary text-gray-900 rounded-lg hover:bg-secondary/90 transition-colors;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,8 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#0066cc',
-        secondary: '#ff6600',
+        primary: '#1E6BF1',
+        secondary: '#C0C0C0',
       },
       fontFamily: {
         sans: ['Inter', 'sans-serif'],


### PR DESCRIPTION
## Summary
- switch primary/secondary palette to blue/silver
- update global styles and components to use new colors
- enlarge CSRental logo across header and pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b707cf8d5c832ba53933f0f2e9a6c7