### PR TITLE
Improve chat session persistence and sidebar refresh

### DIFF
--- a/components/ChatSidebar.tsx
+++ b/components/ChatSidebar.tsx
@@ -35,6 +35,10 @@ export default function ChatSidebar({
     fetchChatSessions();
   }, [mode, showArchived]);
 
+  useEffect(() => {
+    fetchChatSessions();
+  }, [currentSessionId]);
+
   async function fetchChatSessions() {
     try {
       const { data: { user } } = await supabase.auth.getUser();
@@ -189,7 +193,10 @@ export default function ChatSidebar({
           </div>
 
           <button
-            onClick={onNewChat}
+            onClick={() => {
+              onNewChat();
+              fetchChatSessions();
+            }}
             className="w-full bg-secondary hover:bg-secondary/90 text-gray-900 rounded-lg py-2 px-3 text-sm font-medium transition-colors flex items-center justify-center shadow"
           >
             <span className="mr-2">+</span>

--- a/hooks/useChatSession.ts
+++ b/hooks/useChatSession.ts
@@ -89,8 +89,8 @@ export function useChatSession(mode: 'technical' | 'procurement') {
         .select()
         .single();
 
-      if (error) {
-        console.error('Error creating chat session:', error);
+      if (error || !data) {
+        console.error('Error creating chat session:', error || 'No data returned');
         return null;
       }
 
@@ -121,13 +121,13 @@ export function useChatSession(mode: 'technical' | 'procurement') {
         .select('id')
         .single();
 
-      if (error) {
-        console.error('Error saving message:', error);
+      if (error || !data) {
+        console.error('Error saving message:', error || 'No data returned');
         return null;
-      } else {
-        console.log('Message saved successfully with ID:', data.id);
-        return data.id;
       }
+
+      console.log('Message saved successfully with ID:', data.id);
+      return data.id;
     } catch (error) {
       console.error('Error saving message:', error);
       return null;


### PR DESCRIPTION
## Summary
- add stricter Supabase insert checks for new sessions and messages
- refresh chat sidebar whenever session ID changes or new chat starts
- document chat schema for sessions and messages

## Testing
- `npm test`
- `bash e2e-test.sh` *(fails: Next.js build, Supabase connection, OpenAI connection, vector search, dev server)*

------
https://chatgpt.com/codex/tasks/task_e_68b70f5371ec832b9d0ce87779b0d766