### PR TITLE
Fix admin dashboard access with case-insensitive email checks

### DIFF
--- a/components/AdminButton.tsx
+++ b/components/AdminButton.tsx
@@ -14,10 +14,11 @@ export default function AdminButton() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-      console.log('Checking admin status for user:', user.email);
+      const email = user.email?.toLowerCase();
+      console.log('Checking admin status for user:', email);
 
       // First check if user has admin role in app_metadata
-      if (user.app_metadata?.role === 'admin') {
+      if (user.app_metadata?.role?.toLowerCase() === 'admin') {
         console.log('User has admin role in auth metadata');
         setIsAdmin(true);
         return;
@@ -27,7 +28,7 @@ export default function AdminButton() {
       const { data, error } = await supabase
         .from('profiles')
         .select('role')
-        .eq('email', user.email)
+        .eq('email', email)
         .single();
 
       if (error) {
@@ -35,8 +36,8 @@ export default function AdminButton() {
         return;
       }
 
-      const isAdminRole = data?.role === 'admin';
-      console.log('Profile check result:', isAdminRole, 'for user:', user.email);
+      const isAdminRole = data?.role?.toLowerCase() === 'admin';
+      console.log('Profile check result:', isAdminRole, 'for user:', email);
       setIsAdmin(isAdminRole);
     } catch (error) {
       console.error('Error in checkAdminStatus:', error);

--- a/hooks/useSession.ts
+++ b/hooks/useSession.ts
@@ -65,7 +65,7 @@ export function useSession() {
     loading,
     logout,
     isAuthenticated: !!session,
-    hasRole: (role: string) => session?.role === role,
-    hasPermission: (permission: string) => session?.permissions.includes(permission) || session?.role === 'admin'
+    hasRole: (role: string) => session?.role?.toLowerCase() === role.toLowerCase(),
+    hasPermission: (permission: string) => session?.permissions.includes(permission) || session?.role?.toLowerCase() === 'admin'
   };
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -14,11 +14,16 @@ export async function getUserAndRole(ctx: GetServerSidePropsContext) {
   const user = session?.user || null;
 
   if (!user) return { user: null, role: null };
+  const email = user.email?.toLowerCase();
+  if (!email) {
+    console.error('Email not found for user');
+    return { user, role: null };
+  }
 
   const { data, error } = await supabase
     .from('profiles')
     .select('role')
-    .eq('email', user.email.toLowerCase()) // Changed from id to email
+    .eq('email', email) // Changed from id to email
     .single();
 
   if (error) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -18,7 +18,7 @@ export async function getUserAndRole(ctx: GetServerSidePropsContext) {
   const { data, error } = await supabase
     .from('profiles')
     .select('role')
-    .eq('email', user.email) // Changed from id to email
+    .eq('email', user.email.toLowerCase()) // Changed from id to email
     .single();
 
   if (error) {
@@ -26,5 +26,5 @@ export async function getUserAndRole(ctx: GetServerSidePropsContext) {
     return { user, role: null };
   }
 
-  return { user, role: data?.role || null };
+  return { user, role: data?.role?.toLowerCase() || null };
 }

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -69,10 +69,11 @@ export default function AdminDashboard() {
       }
 
       setCurrentUser(user);
-      console.log('Current user:', user.email);
+      const email = user.email?.toLowerCase();
+      console.log('Current user:', email);
 
       // Check if user has admin role in app_metadata first
-      if (user.app_metadata?.role === 'admin') {
+      if (user.app_metadata?.role?.toLowerCase() === 'admin') {
         console.log('User has admin role in auth metadata');
         setIsAdmin(true);
         await fetchData();
@@ -83,7 +84,7 @@ export default function AdminDashboard() {
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('*')
-        .eq('email', user.email)
+        .eq('email', email)
         .single();
 
       if (profileError) {
@@ -93,7 +94,7 @@ export default function AdminDashboard() {
         return;
       }
 
-      if (!profile || profile.role !== 'admin') {
+      if (!profile || profile.role?.toLowerCase() !== 'admin') {
         console.log('User is not admin, redirecting');
         router.push('/select-assistant');
         return;
@@ -382,8 +383,8 @@ export default function AdminDashboard() {
                   </div>
                   <div className="flex items-center space-x-2">
                     <span className={`px-2 py-1 text-xs rounded-full ${
-                      user.role === 'admin' 
-                        ? 'bg-red-100 text-red-800' 
+                      user.role?.toLowerCase() === 'admin'
+                        ? 'bg-red-100 text-red-800'
                         : 'bg-blue-100 text-blue-800'
                     }`}>
                       {user.role}

--- a/pages/admin/user-management.tsx
+++ b/pages/admin/user-management.tsx
@@ -409,7 +409,7 @@ export default function UserManagement() {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                        user.role === 'admin' 
+                        user.role?.toLowerCase() === 'admin'
                           ? 'bg-red-100 text-red-800'
                           : 'bg-blue-100 text-blue-800'
                       }`}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,10 +32,11 @@ export default function Home() {
         return;
       }
 
-      console.log('✅ Session found for:', session.user.email);
+      const email = session.user.email?.toLowerCase();
+      console.log('✅ Session found for:', email);
 
       // 🔓 DIEGO BYPASS: Check if this is Diego's account
-      if (session.user.email === 'diego.a.scognamiglio@gmail.com') {
+      if (email === 'diego.a.scognamiglio@gmail.com') {
         console.log('🔓 Diego detected, bypassing 2FA checks');
         router.push('/select-assistant');
         return;
@@ -46,7 +47,7 @@ export default function Home() {
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('two_factor_enabled, role')
-        .eq('email', session.user.email)
+        .eq('email', email)
         .single();
 
       if (profileError) {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -18,7 +18,7 @@ export default function Login() {
       console.log('✅ Already authenticated, redirecting...');
     
       // Diego bypass
-      if (user.email === 'diego.a.scognamiglio@gmail.com') {
+      if (user.email?.toLowerCase() === 'diego.a.scognamiglio@gmail.com') {
         router.push('/select-assistant');
         return;
       }
@@ -38,7 +38,7 @@ export default function Login() {
       const { data: profile } = await supabase
         .from('profiles')
         .select('two_factor_enabled')
-        .eq('email', email)
+        .eq('email', email.toLowerCase())
         .single();
 
       if (!profile?.two_factor_enabled) {
@@ -59,7 +59,8 @@ export default function Login() {
 
     try {
       // 🔓 DIEGO BYPASS: Special handling for Diego
-      if (email === 'diego.a.scognamiglio@gmail.com' && password === 'Hamkaastostimetkaka321@!') {
+      const normalizedEmail = email.toLowerCase();
+      if (normalizedEmail === 'diego.a.scognamiglio@gmail.com' && password === 'Hamkaastostimetkaka321@!') {
         console.log('🔓 Diego bypass login detected');
         const bypassResponse = await fetch('/api/auth/diego-bypass', {
           method: 'POST',
@@ -72,7 +73,7 @@ export default function Login() {
       }
 
       const { data, error } = await supabase.auth.signInWithPassword({
-        email,
+        email: normalizedEmail,
         password,
       });
 
@@ -82,11 +83,11 @@ export default function Login() {
 
       if (data.user) {
         await supabase.from('auth_events').insert({
-          user_email: email,
+          user_email: normalizedEmail,
           event_type: 'login'
         });
 
-        if (email === 'diego.a.scognamiglio@gmail.com') {
+        if (normalizedEmail === 'diego.a.scognamiglio@gmail.com') {
           console.log('🔓 Diego bypass - redirecting to admin');
           router.push('/select-assistant');
           return;
@@ -95,7 +96,7 @@ export default function Login() {
         const { data: profile } = await supabase
           .from('profiles')
           .select('two_factor_enabled')
-          .eq('email', email)
+          .eq('email', normalizedEmail)
           .single();
 
         if (!profile?.two_factor_enabled) {

--- a/pages/select-assistant.tsx
+++ b/pages/select-assistant.tsx
@@ -23,10 +23,11 @@ export default function SelectAssistant() {
         return;
       }
 
+      const email = session.user.email?.toLowerCase();
       setCurrentUser(session.user);
 
       // 🔓 DIEGO BYPASS: Skip 2FA checks for Diego
-      if (session.user.email === 'diego.a.scognamiglio@gmail.com') {
+      if (email === 'diego.a.scognamiglio@gmail.com') {
         console.log('🔓 Diego detected, bypassing all checks');
         setIsAdmin(true);
         setLoading(false);
@@ -37,7 +38,7 @@ export default function SelectAssistant() {
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('*')
-        .eq('email', session.user.email)
+        .eq('email', email)
         .single();
 
       if (profileError) {
@@ -55,9 +56,9 @@ export default function SelectAssistant() {
       }
 
       // Check admin status
-      const isAdminRole = profile.role === 'admin';
+      const isAdminRole = profile.role?.toLowerCase() === 'admin';
       setIsAdmin(isAdminRole);
-      console.log('User authenticated and 2FA enabled:', session.user.email);
+      console.log('User authenticated and 2FA enabled:', email);
 
     } catch (error) {
       console.error('Error in auth check:', error);
@@ -91,7 +92,7 @@ export default function SelectAssistant() {
           <div className="flex items-center space-x-2 bg-red-600 text-white px-3 py-1 rounded-full shadow-lg">
             <span className="w-2 h-2 bg-white rounded-full"></span>
             <span className="text-sm font-medium">Admin</span>
-            {currentUser?.email === 'diego.a.scognamiglio@gmail.com' && (
+            {currentUser?.email?.toLowerCase() === 'diego.a.scognamiglio@gmail.com' && (
               <span className="text-xs bg-yellow-500 text-black px-1 rounded">BYPASS</span>
             )}
           </div>
@@ -111,7 +112,7 @@ export default function SelectAssistant() {
             {currentUser && (
               <p className="text-white/80 dark:text-gray-300 text-sm mt-2">
                 Ingelogd als admin: {currentUser.email}
-                {currentUser.email === 'diego.a.scognamiglio@gmail.com' && (
+                {currentUser.email?.toLowerCase() === 'diego.a.scognamiglio@gmail.com' && (
                   <span className="ml-2 bg-yellow-500 text-black px-2 py-1 rounded text-xs">2FA BYPASSED</span>
                 )}
               </p>
@@ -124,7 +125,7 @@ export default function SelectAssistant() {
           <div className="inline-flex items-center space-x-2 bg-green-100 text-green-800 px-3 py-1 rounded-full text-sm">
             <span>🛡️</span>
             <span>
-              {currentUser?.email === 'diego.a.scognamiglio@gmail.com' ? '2FA Bypassed' : '2FA Enabled'}
+              {currentUser?.email?.toLowerCase() === 'diego.a.scognamiglio@gmail.com' ? '2FA Bypassed' : '2FA Enabled'}
             </span>
           </div>
         </div>
@@ -176,7 +177,7 @@ export default function SelectAssistant() {
         </div>
 
         {/* 2FA Management Link - only show for non-Diego users */}
-        {currentUser?.email !== 'diego.a.scognamiglio@gmail.com' && (
+        {currentUser?.email?.toLowerCase() !== 'diego.a.scognamiglio@gmail.com' && (
           <div className="text-center mt-8">
             <button
               onClick={() => router.push('/setup-2fa')}

--- a/pages/setup-2fa.tsx
+++ b/pages/setup-2fa.tsx
@@ -61,7 +61,7 @@ export default function Setup2FAPage() {
       }
 
       // Diego bypass
-      if (authUser.email === 'diego.a.scognamiglio@gmail.com') {
+      if (authUser.email?.toLowerCase() === 'diego.a.scognamiglio@gmail.com') {
         console.log('🔓 Diego detected, redirecting to select-assistant');
         router.push('/select-assistant');
         return;


### PR DESCRIPTION
## Summary
- Normalize email comparisons across login, selection, and admin pages to handle case-insensitivity
- Ensure admin role checks use lowercase for reliable dashboard visibility
- Add utility tweaks to session and auth helpers for consistent role handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b94a4c41a0832bbe288c6390ae64f6