### PR TITLE
feat: pass original query to fallback search

### DIFF
--- a/lib/rag/pipeline.ts
+++ b/lib/rag/pipeline.ts
@@ -66,6 +66,7 @@ export class RAGPipeline {
 
       const results = await this.vectorStore.searchSimilarDocuments(
         embeddingResponse[0].embedding,
+        query,
         RAG_CONFIG.similarityThreshold,
         RAG_CONFIG.maxResults
       );

--- a/lib/rag/vectorStore.ts
+++ b/lib/rag/vectorStore.ts
@@ -42,6 +42,7 @@ export class VectorStore {
 
   async searchSimilarDocuments(
     queryEmbedding: number[],
+    originalQuery: string,
     threshold: number = 0.7,
     limit: number = 5,
     filter?: { afdeling?: string, categorie?: string, klant_id?: string }
@@ -120,7 +121,7 @@ export class VectorStore {
       console.error('❌ Error in similarity search:', error instanceof Error ? error.message : error);
       
       // Fallback to text search if vector search fails
-      return await this.fallbackTextSearch('', limit, filter);
+      return await this.fallbackTextSearch(originalQuery, limit, filter);
     }
   }
 


### PR DESCRIPTION
## Summary
- accept original query in vector search and forward to text fallback
- pipeline supplies user query to vector store search

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bee7034520832ba10e9bc37738eac8