### PR TITLE
feat: add script to upload documents to supabase

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -26,6 +26,10 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
+# Document Upload Configuration
+SUPABASE_DOCUMENTS_BUCKET=documents
+LOCAL_DOCUMENTS_PATH=/path/to/documents
+
 # OpenAI Configuration (REQUIRED)
 OPENAI_API_KEY=your_openai_api_key_here
 OPENAI_MODEL=gpt-4-turbo

--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Inhouse AI chatbot omgeving voor CS Rental, schaalbaar voor meerdere klanten.
 - `npm run bulk-upload:verify` – controleer of uploads correct zijn verwerkt.
 - `npm run mirror-folders` – spiegel lokale mappen naar Supabase.
 - `npm run upload-from-drive` – upload bestanden vanaf een lokale schijf.
+- `npm run upload:all-docs -- <pad>` – upload alle documenten uit een lokale map naar Supabase Storage.
+
+### Automatisch uploaden
+Je kunt deze script handmatig draaien of automatiseren met een cron-job om nieuwe bestanden te uploaden. Voorbeeld (elk uur):
+
+```bash
+0 * * * * cd /pad/naar/project && npm run upload:all-docs -- /pad/naar/documenten >> upload.log 2>&1
+```
 
 ## Supabase
 Supabase levert de Postgres‑database, authenticatie en opslag. De SQL‑migraties staan in `supabase/migrations`.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bulk-upload:verify": "node scripts/bulk-upload-verify.js",
     "mirror-folders": "node scripts/mirror-folders.js",
     "upload-from-drive": "node scripts/bulk-upload-from-local-drive.js",
+    "upload:all-docs": "ts-node scripts/upload-all-docs.ts",
     "test": "jest"
   },
   "dependencies": {

--- a/scripts/upload-all-docs.ts
+++ b/scripts/upload-all-docs.ts
@@ -1,0 +1,58 @@
+import { createClient } from '@supabase/supabase-js';
+import { promises as fs } from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+
+// Load env vars from .env and .env.local if present
+dotenv.config();
+dotenv.config({ path: '.env.local', override: true });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const BUCKET = process.env.SUPABASE_DOCUMENTS_BUCKET || 'documents';
+const ROOT = process.env.LOCAL_DOCUMENTS_PATH || process.argv[2];
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('❌ Missing Supabase credentials.');
+  process.exit(1);
+}
+
+if (!ROOT) {
+  console.error('❌ Please provide a directory to scan.');
+  console.error('   Usage: ts-node scripts/upload-all-docs.ts <directory>');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+async function walk(dir: string, base: string): Promise<void> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(fullPath, base);
+    } else {
+      const storagePath = path.relative(base, fullPath).replace(/\\/g, '/');
+      try {
+        const file = await fs.readFile(fullPath);
+        const { error } = await supabase.storage
+          .from(BUCKET)
+          .upload(storagePath, file, { upsert: false });
+        if (error) {
+          console.error(`⚠️  Failed to upload ${storagePath}: ${error.message}`);
+        } else {
+          console.log(`✅ Uploaded ${storagePath}`);
+        }
+      } catch (err: any) {
+        console.error(`⚠️  Error reading ${fullPath}: ${err.message}`);
+      }
+    }
+  }
+}
+
+walk(ROOT, ROOT)
+  .then(() => console.log('🎉 Upload complete'))
+  .catch(err => {
+    console.error('❌ Unexpected error:', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add upload-all-docs script to send local files to Supabase storage
- document env vars and cron usage for document uploads
- expose npm script for running the uploader

## Testing
- `npm test`
- `npx ts-node scripts/upload-all-docs.ts tests` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68bf14c8db44832ba4f50ed224821bda