### PR TITLE
Fix ingestion script to include chunk index

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -111,9 +111,11 @@ class DocumentIngestor:
         try:
             data_to_insert = []
             for chunk, embedding in zip(chunks, embeddings):
+                chunk_meta = chunk['metadata']
                 data_to_insert.append({
                     'content': chunk['content'],
-                    'metadata': chunk['metadata'],
+                    'metadata': {k: v for k, v in chunk_meta.items() if k != 'chunk_index'},
+                    'chunk_index': chunk_meta.get('chunk_index'),
                     'embedding': embedding,
                     'created_at': time.strftime('%Y-%m-%d %H:%M:%S')
                 })


### PR DESCRIPTION
## Summary
- include chunk_index field when storing document chunks to Supabase

## Testing
- `python ingest.py docs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf263eb828832b9d4b93214f2dfe99