### PR TITLE
Use Supabase storage API for document downloads

### DIFF
--- a/scripts/process-all-pending-documents.js
+++ b/scripts/process-all-pending-documents.js
@@ -110,7 +110,7 @@ async function processBatch(docs, concurrency) {
 
 async function processDocument(document) {
   try {
-    const { data: fileData, error: downloadError } = await supabaseAdmin
+    const { data: fileData, error: downloadError } = await supabaseAdmin.storage
       .from('company-docs') // bucket
       .download(document.storage_path);
     if (downloadError) throw new Error(`Failed to download: ${downloadError.message}`);


### PR DESCRIPTION
## Summary
- use `supabaseAdmin.storage` API to download files in `process-all-pending-documents.js`

## Testing
- `npm test`
- `node scripts/process-all-pending-documents.js` *(fails: Missing Supabase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68bf30e12200832ba6fb6886788dcc52