### PR TITLE
Use env site URL for password reset redirect

### DIFF
--- a/pages/forgot-password.tsx
+++ b/pages/forgot-password.tsx
@@ -17,7 +17,7 @@ export default function ForgotPassword() {
 
     try {
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/reset-password`,
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || window.location.origin}/reset-password`,
       });
 
       if (error) {


### PR DESCRIPTION
## Summary
- reference NEXT_PUBLIC_SITE_URL when building password reset redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c15c5c6048832bb9f1f512be3f9ae2