### PR TITLE
feat: allow dashboard access without admin role

### DIFF
--- a/components/AdminButton.tsx
+++ b/components/AdminButton.tsx
@@ -1,51 +1,6 @@
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { supabase } from '../lib/supabaseClient';
 
 export default function AdminButton() {
-  const [isAdmin, setIsAdmin] = useState(false);
-
-  useEffect(() => {
-    checkAdminStatus();
-  }, []);
-
-  async function checkAdminStatus() {
-    try {
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return;
-
-      const email = user.email?.toLowerCase();
-      console.log('Checking admin status for user:', email);
-
-      // First check if user has admin role in app_metadata
-      if (user.app_metadata?.role?.toLowerCase() === 'admin') {
-        console.log('User has admin role in auth metadata');
-        setIsAdmin(true);
-        return;
-      }
-
-      // Then check profiles table by email
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('role')
-        .eq('email', email)
-        .single();
-
-      if (error) {
-        console.error('Error checking admin status:', error);
-        return;
-      }
-
-      const isAdminRole = data?.role?.toLowerCase() === 'admin';
-      console.log('Profile check result:', isAdminRole, 'for user:', email);
-      setIsAdmin(isAdminRole);
-    } catch (error) {
-      console.error('Error in checkAdminStatus:', error);
-    }
-  }
-
-  if (!isAdmin) return null;
-
   return (
     <Link
       href="/admin"

--- a/pages/api/security/audit-logs.ts
+++ b/pages/api/security/audit-logs.ts
@@ -27,26 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Invalid token' });
     }
 
-    // Check if user is admin
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('email', user.email)
-      .single();
-
-    if (!profile || profile.role !== 'admin') {
-      await auditLogger.logSecurity({
-        type: 'UNAUTHORIZED_ACCESS',
-        severity: 'WARN',
-        details: {
-          resource: 'audit_logs',
-          userEmail: user.email,
-          reason: 'insufficient_privileges'
-        }
-      }, user.id, clientIP);
-
-      return res.status(403).json({ error: 'Admin access required' });
-    }
+    // Admin role check removed to allow broader access
 
     if (req.method === 'GET') {
       const {

--- a/pages/api/security/scan.ts
+++ b/pages/api/security/scan.ts
@@ -32,16 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Invalid token' });
     }
 
-    // Check if user is admin
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('email', user.email)
-      .single();
-
-    if (!profile || profile.role !== 'admin') {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
+    // Admin role check removed to allow broader access
 
     const { scanType = 'full' } = req.body;
 

--- a/pages/api/test-rag-pipeline.ts
+++ b/pages/api/test-rag-pipeline.ts
@@ -32,16 +32,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(401).json({ error: 'Invalid token' });
     }
 
-    // Check if user is admin
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('email', user.email)
-      .single();
-
-    if (!profile || profile.role !== 'admin') {
-      return res.status(403).json({ error: 'Admin access required' });
-    }
+    // Admin role check removed to allow broader access
 
     const { action, documentId, query } = req.body;
 


### PR DESCRIPTION
## Summary
- always show admin dashboard button
- remove admin role checks from security and RAG endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2ba140768832b8fd2bbae34835996