### PR TITLE
Harden RAG ingestion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Voeg de vereiste variabelen toe aan je `.env.local` bestand. Bekijk `.env.local.
 - `npm run rag:create-test-docs` – maak testdocumenten aan.
 - `npm run rag:test` – opent de RAG‑testpagina.
 
+De volledige ingest‑pipeline gebruikt de variabelen `SUPABASE_DOCUMENTS_BUCKET`, `RAG_EMBEDDING_MODEL`, `RAG_CHUNK_SIZE`, `RAG_CHUNK_OVERLAP`, `RAG_BATCH_SIZE`, `RAG_CONCURRENCY` en `RAG_DELAY_MS`. Je kunt veilig herhaaldelijk `node scripts/process-all-pending-documents.js` draaien; reeds verwerkte documenten worden overgeslagen tenzij je `--force` meegeeft.
+
 ### Bulk upload
 - `npm run bulk-upload` – bulkupload van documenten.
 - `npm run bulk-upload:handleidingen` – upload handleidingen in bulk.

--- a/lib/rag/config.ts
+++ b/lib/rag/config.ts
@@ -1,31 +1,49 @@
 import { createClient } from '@supabase/supabase-js';
 
+const toInt = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toFloat = (value: string | undefined, fallback: number): number => {
+  if (!value) return fallback;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
 // Safely access environment variables with fallbacks
 export const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
 export const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'placeholder-key';
-export const openaiApiKey = process.env.OPENAI_API_KEY || 'placeholder-key';
+export const openaiApiKey = process.env.OPENAI_API_KEY || '';
 
-// Validate environment variables
-if (!supabaseUrl || supabaseUrl === 'https://placeholder.supabase.co') {
+if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable');
 }
 
-if (!supabaseAnonKey || supabaseAnonKey === 'placeholder-key') {
+if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_ANON_KEY environment variable');
 }
 
-if (!openaiApiKey || openaiApiKey === 'placeholder-key') {
+if (!openaiApiKey) {
   console.error('Missing OPENAI_API_KEY environment variable');
 }
 
 // Initialize Supabase client
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-// RAG configuration
 export const RAG_CONFIG = {
-  embeddingModel: 'text-embedding-3-small',
-  chunkSize: 1000,
-  chunkOverlap: 200,
-  similarityThreshold: 0.7,
-  maxResults: 5
+  embeddingModel: process.env.RAG_EMBEDDING_MODEL || 'text-embedding-3-small',
+  chunkSize: toInt(process.env.RAG_CHUNK_SIZE, 1000),
+  chunkOverlap: toInt(process.env.RAG_CHUNK_OVERLAP, 200),
+  similarityThreshold: toFloat(process.env.RAG_SIMILARITY_THRESHOLD, 0.7),
+  maxResults: toInt(process.env.RAG_MAX_RESULTS, 5),
+  batchSize: toInt(process.env.RAG_BATCH_SIZE, 20),
+  concurrency: Math.max(1, toInt(process.env.RAG_CONCURRENCY, 2)),
+  delayMs: Math.max(0, toInt(process.env.RAG_DELAY_MS, 200)),
+  ocrMinTextLength: Math.max(0, toInt(process.env.OCR_MIN_TEXT_LEN, 50)),
+  retryMax: Math.max(1, toInt(process.env.RETRY_MAX, 5)),
+  documentsBucket: process.env.SUPABASE_DOCUMENTS_BUCKET || '',
 };
+
+export const EMBEDDING_DIMENSIONS = 1536;

--- a/lib/rag/embeddingGenerator.ts
+++ b/lib/rag/embeddingGenerator.ts
@@ -1,5 +1,16 @@
 import OpenAI from 'openai';
+import { RAG_CONFIG, EMBEDDING_DIMENSIONS } from './config';
+import { RetryableError } from './errors';
 import { TextChunk } from './types';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type BatchOptions = {
+  batchSize?: number;
+  concurrency?: number;
+  delayMs?: number;
+  retryMax?: number;
+};
 
 export class EmbeddingGenerator {
   private openai: OpenAI;
@@ -8,60 +19,123 @@ export class EmbeddingGenerator {
     this.openai = new OpenAI({ apiKey });
   }
 
-  async generateEmbeddings(chunks: TextChunk[], model: string): Promise<TextChunk[]> {
-    console.log(`🧠 Generating embeddings for ${chunks.length} chunks using ${model}...`);
-    
-    const embeddedChunks: TextChunk[] = [];
-    const batchSize = 20; // Process in batches to avoid rate limits
+  async generateEmbeddings(
+    chunks: TextChunk[],
+    model: string,
+    options: BatchOptions = {}
+  ): Promise<TextChunk[]> {
+    if (!chunks.length) {
+      return [];
+    }
 
-    // Process chunks in batches
+    const batchSize = options.batchSize ?? RAG_CONFIG.batchSize;
+    const concurrency = options.concurrency ?? RAG_CONFIG.concurrency;
+    const delayMs = options.delayMs ?? RAG_CONFIG.delayMs;
+    const retryMax = options.retryMax ?? RAG_CONFIG.retryMax;
+
+    const batches: TextChunk[][] = [];
     for (let i = 0; i < chunks.length; i += batchSize) {
-      const batch = chunks.slice(i, Math.min(i + batchSize, chunks.length));
-      console.log(`📦 Processing batch ${Math.floor(i/batchSize) + 1}/${Math.ceil(chunks.length/batchSize)} (${batch.length} chunks)`);
-      
-      try {
-        // Extract content from each chunk in the batch
-        const contents = batch.map(chunk => chunk.content);
+      batches.push(chunks.slice(i, Math.min(i + batchSize, chunks.length)));
+    }
 
-        // Generate embeddings for the entire batch
-        const embeddingResponse = await this.openai.embeddings.create({
+    const embeddedChunks: TextChunk[] = [];
+    let nextBatchIndex = 0;
+
+    const worker = async () => {
+      while (nextBatchIndex < batches.length) {
+        const currentIndex = nextBatchIndex++;
+        const batch = batches[currentIndex];
+
+        const embedded = await this.processBatch({
+          batch,
+          model,
+          batchIndex: currentIndex,
+          totalBatches: batches.length,
+          retryMax,
+        });
+
+        embeddedChunks.push(...embedded);
+
+        if (delayMs > 0 && nextBatchIndex < batches.length) {
+          await sleep(delayMs);
+        }
+      }
+    };
+
+    const workers = Array.from({ length: Math.min(concurrency, batches.length) }, () => worker());
+    await Promise.all(workers);
+
+    return embeddedChunks;
+  }
+
+  private async processBatch({
+    batch,
+    model,
+    batchIndex,
+    totalBatches,
+    retryMax,
+  }: {
+    batch: TextChunk[];
+    model: string;
+    batchIndex: number;
+    totalBatches: number;
+    retryMax: number;
+  }): Promise<TextChunk[]> {
+    let attempt = 0;
+
+    while (attempt <= retryMax) {
+      try {
+        console.log(
+          `📦 Generating embeddings batch ${batchIndex + 1}/${totalBatches} (size=${batch.length}) attempt=${attempt + 1}`
+        );
+
+        const contents = batch.map((chunk) => chunk.content);
+        const response = await this.openai.embeddings.create({
           model,
           input: contents,
         });
 
-        if (
-          !embeddingResponse.data ||
-          embeddingResponse.data.length !== batch.length ||
-          embeddingResponse.data.some(d => !d.embedding)
-        ) {
-          console.error(
-            `❌ Embedding response missing data for batch starting at chunk ${i}`
-          );
+        if (!response.data || response.data.length !== batch.length) {
           throw new Error('Embedding response missing data');
         }
 
-        // Add embeddings to chunks
-        for (let j = 0; j < batch.length; j++) {
-          embeddedChunks.push({
-            ...batch[j],
-            embedding: embeddingResponse.data[j].embedding,
-          });
+        return batch.map((chunk, idx) => {
+          const embedding = response.data[idx]?.embedding;
+          if (!embedding) {
+            throw new Error(`Embedding missing for chunk index ${idx}`);
+          }
+          if (embedding.length !== EMBEDDING_DIMENSIONS) {
+            throw new Error(
+              `Embedding dimension mismatch: expected ${EMBEDDING_DIMENSIONS}, received ${embedding.length}`
+            );
+          }
+          return {
+            ...chunk,
+            embedding,
+          };
+        });
+      } catch (error: any) {
+        const status = error?.status ?? error?.statusCode ?? error?.response?.status;
+        const isRetryable = status === 429 || (typeof status === 'number' && status >= 500);
+
+        if (!isRetryable || attempt >= retryMax) {
+          if (isRetryable && attempt >= retryMax) {
+            throw new RetryableError('Embedding retries exhausted', error);
+          }
+          throw error;
         }
 
-        // Small delay to avoid rate limiting
-        if (i + batchSize < chunks.length) {
-          await new Promise(resolve => setTimeout(resolve, 200));
-        }
-      } catch (error) {
-        console.error(
-          `❌ Error generating embeddings for batch starting at chunk ${i}:`,
-          error
+        const delay = Math.min(60_000, Math.pow(2, attempt) * 1000);
+        console.warn(
+          `⚠️ Embedding batch ${batchIndex + 1} retry ${attempt + 1}/${retryMax} after ${delay}ms due to ${
+            status || error?.code || 'unknown'
+          }`
         );
-        throw error;
+        attempt += 1;
+        await sleep(delay);
       }
     }
 
-    console.log(`✅ Generated embeddings for ${embeddedChunks.filter(c => c.embedding).length}/${chunks.length} chunks`);
-    return embeddedChunks;
+    throw new RetryableError('Embedding retries exhausted');
   }
 }

--- a/lib/rag/errors.ts
+++ b/lib/rag/errors.ts
@@ -1,0 +1,18 @@
+export class RetryableError extends Error {
+  public readonly cause?: unknown;
+
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'RetryableError';
+    this.cause = cause;
+  }
+}
+
+export const isRetryableError = (error: unknown): boolean => {
+  if (!error) return false;
+  if (error instanceof RetryableError) return true;
+  if (typeof error === 'object' && 'isRetryable' in (error as any)) {
+    return Boolean((error as any).isRetryable);
+  }
+  return false;
+};

--- a/lib/rag/extract-text.ts
+++ b/lib/rag/extract-text.ts
@@ -3,6 +3,9 @@ import mammoth from 'mammoth';
 import { createWorker } from 'tesseract.js';
 import path from 'path';
 
+import sharp from 'sharp';
+import { RAG_CONFIG } from './config';
+
 export type ExtractKind =
   | 'pdf'
   | 'docx'
@@ -16,6 +19,51 @@ export interface ExtractTextResult {
   kind: ExtractKind;
   mime: string;
   text: string;
+  ocrAttempted: boolean;
+  usedOcr: boolean;
+}
+
+const normaliseText = (text: string) => text?.replace(/\u0000/g, '').trim();
+
+async function recogniseImages(buffers: Buffer[]): Promise<string> {
+  if (!buffers.length) return '';
+
+  const worker = await createWorker('nld+eng');
+  try {
+    const pieces: string[] = [];
+    for (const buffer of buffers) {
+      const processed = await sharp(buffer).ensureAlpha().grayscale().toFormat('png').toBuffer();
+      const { data } = await worker.recognize(processed);
+      if (data?.text) {
+        pieces.push(data.text);
+      }
+    }
+    return normaliseText(pieces.join('\n\n')) || '';
+  } finally {
+    await worker.terminate();
+  }
+}
+
+async function ocrPdf(buffer: Buffer): Promise<string> {
+  try {
+    const base = sharp(buffer, { density: 300 });
+    const metadata = await base.metadata();
+    const pages = metadata.pages && metadata.pages > 0 ? metadata.pages : 1;
+    const images: Buffer[] = [];
+
+    for (let page = 0; page < pages; page++) {
+      const pageBuffer = await sharp(buffer, { density: 300, page })
+        .grayscale()
+        .toFormat('png')
+        .toBuffer();
+      images.push(pageBuffer);
+    }
+
+    return await recogniseImages(images);
+  } catch (error) {
+    console.error('❌ PDF OCR failed', error);
+    return '';
+  }
 }
 
 export async function extractText(
@@ -34,53 +82,76 @@ export async function extractText(
   if (!detectedMime) {
     if (ext === '.txt') detectedMime = 'text/plain';
     else if (ext === '.md' || ext === '.markdown') detectedMime = 'text/markdown';
+    else if (ext === '.docx') {
+      detectedMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    }
   }
 
   switch (detectedMime) {
     case 'application/pdf': {
       try {
         const pdfData = await pdfParse(buffer);
-        const text = (pdfData.text || '').trim();
-        if (!text) {
-          return { kind: 'pdf-scan', mime: detectedMime, text: '' };
+        const text = normaliseText(pdfData.text || '') || '';
+        if (text.length >= RAG_CONFIG.ocrMinTextLength) {
+          return { kind: 'pdf', mime: detectedMime, text, ocrAttempted: false, usedOcr: false };
         }
-        return { kind: 'pdf', mime: detectedMime, text };
-      } catch {
-        return { kind: 'pdf-scan', mime: detectedMime, text: '' };
+
+        const ocrText = await ocrPdf(buffer);
+        return {
+          kind: 'pdf-scan',
+          mime: detectedMime,
+          text: normaliseText(ocrText) || '',
+          ocrAttempted: true,
+          usedOcr: true,
+        };
+      } catch (error) {
+        console.error('❌ PDF parse failed', error);
+        const ocrText = await ocrPdf(buffer);
+        return {
+          kind: 'pdf-scan',
+          mime: detectedMime,
+          text: normaliseText(ocrText) || '',
+          ocrAttempted: true,
+          usedOcr: Boolean(ocrText),
+        };
       }
     }
     case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
       try {
         const docxData = await mammoth.extractRawText({ buffer });
-        const text = (docxData.value || '').trim();
-        return { kind: 'docx', mime: detectedMime, text };
-      } catch {
-        return { kind: 'docx', mime: detectedMime, text: '' };
+        const text = normaliseText(docxData.value || '') || '';
+        return { kind: 'docx', mime: detectedMime, text, ocrAttempted: false, usedOcr: false };
+      } catch (error) {
+        console.error('❌ DOCX parse failed', error);
+        return { kind: 'docx', mime: detectedMime, text: '', ocrAttempted: false, usedOcr: false };
       }
     }
     case 'text/plain': {
-      const text = buffer.toString('utf-8');
-      return { kind: 'txt', mime: detectedMime, text };
+      const text = normaliseText(buffer.toString('utf-8')) || '';
+      return { kind: 'txt', mime: detectedMime, text, ocrAttempted: false, usedOcr: false };
     }
     case 'text/markdown': {
-      const text = buffer.toString('utf-8');
-      return { kind: 'md', mime: detectedMime, text };
+      const text = normaliseText(buffer.toString('utf-8')) || '';
+      return { kind: 'md', mime: detectedMime, text, ocrAttempted: false, usedOcr: false };
     }
     case 'image/png':
     case 'image/jpeg':
     case 'image/jpg':
-    case 'image/tiff': {
-      try {
-        const worker = await createWorker('nld+eng');
-        const { data } = await worker.recognize(buffer);
-        await worker.terminate();
-        const text = (data.text || '').trim();
-        return { kind: 'image', mime: detectedMime, text };
-      } catch {
-        return { kind: 'image', mime: detectedMime, text: '' };
-      }
+    case 'image/tiff':
+    case 'image/tif':
+    case 'image/bmp':
+    case 'image/gif': {
+      const ocrText = await recogniseImages([buffer]);
+      return {
+        kind: 'image',
+        mime: detectedMime,
+        text: normaliseText(ocrText) || '',
+        ocrAttempted: true,
+        usedOcr: true,
+      };
     }
-    default:
-      return { kind: 'unknown', mime: detectedMime, text: '' };
+    default: {
+      return { kind: 'unknown', mime: detectedMime, text: '', ocrAttempted: false, usedOcr: false };
+    }
   }
 }

--- a/lib/rag/pipeline.ts
+++ b/lib/rag/pipeline.ts
@@ -1,78 +1,74 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { DocumentProcessor } from './documentProcessor';
 import { EmbeddingGenerator } from './embeddingGenerator';
-import { VectorStore } from './vectorStore';
-import type { DocumentMetadata, ProcessingOptions } from './types';
+import { RetryableError } from './errors';
 import { RAG_CONFIG } from './config';
+import type { DocumentMetadata, ProcessingOptions } from './types';
+import { VectorStore } from './vectorStore';
+
+type PipelineOptions = {
+  dryRun?: boolean;
+};
 
 export class RAGPipeline {
-  private supabaseAdmin: SupabaseClient;
   private documentProcessor: DocumentProcessor;
   private embeddingGenerator: EmbeddingGenerator;
   private vectorStore: VectorStore;
 
   constructor(supabaseAdmin: SupabaseClient, openAIKey: string) {
-    this.supabaseAdmin = supabaseAdmin;
-    this.documentProcessor = new DocumentProcessor(supabaseAdmin);
+    this.documentProcessor = new DocumentProcessor();
     this.embeddingGenerator = new EmbeddingGenerator(openAIKey);
     this.vectorStore = new VectorStore(supabaseAdmin);
   }
 
   async processDocument(
     metadata: DocumentMetadata,
-    options: ProcessingOptions
+    options: ProcessingOptions,
+    pipelineOptions: PipelineOptions = {}
   ): Promise<number> {
-    try {
-      console.log(`🔄 Starting RAG pipeline for document: ${metadata.filename}`);
-
-      console.log('📄 Processing document and creating chunks...');
-      const rawChunks = await this.documentProcessor.processDocument(metadata, options);
-      console.log(`✅ Created ${rawChunks.length} chunks`);
-
-      console.log('🧠 Generating embeddings for chunks...');
-      const embeddedChunks = await this.embeddingGenerator.generateEmbeddings(
-        rawChunks,
-        RAG_CONFIG.embeddingModel
-      );
-      console.log(`✅ Generated ${embeddedChunks.length} embeddings`);
-
-      console.log('💾 Storing chunks with embeddings...');
-      await this.vectorStore.storeChunks(embeddedChunks);
-      console.log(`✅ Stored ${embeddedChunks.length} chunks in vector store`);
-
-      console.log('✅ Document processing complete');
-      return embeddedChunks.length;
-    } catch (error) {
-      console.error(
-        `❌ Error in RAG pipeline for document ${metadata.filename}:`,
-        error
-      );
-      throw error;
+    if (!metadata.extractedText || !metadata.extractedText.trim()) {
+      throw new Error('Document metadata is missing extracted text');
     }
+
+    const rawChunks = await this.documentProcessor.processDocument(metadata, options);
+
+    if (!rawChunks.length) {
+      return 0;
+    }
+
+    const embeddedChunks = await this.embeddingGenerator.generateEmbeddings(
+      rawChunks,
+      RAG_CONFIG.embeddingModel
+    );
+
+    if (!embeddedChunks.length) {
+      throw new RetryableError('No embeddings generated');
+    }
+
+    await this.vectorStore.storeChunks(embeddedChunks, {
+      dryRun: pipelineOptions.dryRun || options.dryRun,
+    });
+
+    return embeddedChunks.length;
   }
 
   async searchSimilarDocuments(query: string): Promise<any[]> {
     try {
-      console.log(`🔍 Searching for documents similar to: "${query.substring(0, 50)}..."`);
-
       const embeddingResponse = await this.embeddingGenerator.generateEmbeddings(
         [{ content: query, metadata: {} as DocumentMetadata, chunk_index: 0 }],
         RAG_CONFIG.embeddingModel
       );
 
       if (embeddingResponse.length === 0 || !embeddingResponse[0].embedding) {
-        throw new Error('Failed to generate query embedding');
+        return [];
       }
 
-      const results = await this.vectorStore.searchSimilarDocuments(
+      return await this.vectorStore.searchSimilarDocuments(
         embeddingResponse[0].embedding,
         query,
         RAG_CONFIG.similarityThreshold,
         RAG_CONFIG.maxResults
       );
-
-      console.log(`✅ Found ${results.length} similar documents`);
-      return results;
     } catch (error) {
       console.error('❌ Error searching similar documents:', error);
       return [];

--- a/lib/rag/types.ts
+++ b/lib/rag/types.ts
@@ -3,6 +3,7 @@ export interface DocumentMetadata {
   filename: string;
   safe_filename: string;
   storage_path: string;
+  bucket?: string;
   file_size: number;
   mime_type: string;
   afdeling: string;
@@ -25,7 +26,7 @@ export interface TextChunk {
 }
 
 export interface ProcessingOptions {
-  chunkSize: number;       // max lengte van een chunk
-  chunkOverlap: number;    // overlap tussen chunks
-  skipExisting: boolean;   // skip als al in DB
+  chunkSize: number; // max lengte van een chunk
+  chunkOverlap: number; // overlap tussen chunks
+  dryRun?: boolean;
 }

--- a/lib/server/supabaseAdmin.ts
+++ b/lib/server/supabaseAdmin.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co';
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || 'placeholder-key';
 
 export const supabaseAdmin = createClient(url, serviceKey);

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react": "18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "18.2.0",
+        "sharp": "^0.33.4",
         "speakeasy": "^2.0.0",
         "tailwindcss": "^3.4.1",
         "tesseract.js": "^6.0.1",
@@ -669,9 +670,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -799,10 +800,20 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.2.tgz",
-      "integrity": "sha512-OfXHZPppddivUJnqyKoi5YVeHRkkNE2zUFT2gbpKxp/JZCFYEYubnMg+gOp6lWfasPrTS+KPosKqdI+ELYVDtg==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
       "cpu": [
         "arm64"
       ],
@@ -818,13 +829,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.1.0"
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.2.tgz",
-      "integrity": "sha512-dYvWqmjU9VxqXmjEtjmvHnGqF8GrVjM2Epj9rJ6BUIXvk8slvNDJbhGFvIoXzkDhrJC2jUxNLz/GUjjvSzfw+g==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
       "cpu": [
         "x64"
       ],
@@ -840,13 +851,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.1.0"
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
-      "integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
       "cpu": [
         "arm64"
       ],
@@ -860,9 +871,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
-      "integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
       "cpu": [
         "x64"
       ],
@@ -876,9 +887,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
-      "integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
       "cpu": [
         "arm"
       ],
@@ -892,9 +903,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
-      "integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
       "cpu": [
         "arm64"
       ],
@@ -908,9 +919,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
-      "integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
+      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
       "cpu": [
         "ppc64"
       ],
@@ -924,9 +935,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
-      "integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
       "cpu": [
         "s390x"
       ],
@@ -940,9 +951,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
-      "integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
       "cpu": [
         "x64"
       ],
@@ -956,9 +967,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
-      "integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
       "cpu": [
         "arm64"
       ],
@@ -972,9 +983,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
-      "integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
       "cpu": [
         "x64"
       ],
@@ -988,9 +999,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.2.tgz",
-      "integrity": "sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
       "cpu": [
         "arm"
       ],
@@ -1006,13 +1017,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.1.0"
+        "@img/sharp-libvips-linux-arm": "1.0.5"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.2.tgz",
-      "integrity": "sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
       "cpu": [
         "arm64"
       ],
@@ -1028,13 +1039,35 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.1.0"
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
+      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.2.tgz",
-      "integrity": "sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
       "cpu": [
         "s390x"
       ],
@@ -1050,13 +1083,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.1.0"
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.2.tgz",
-      "integrity": "sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
       "cpu": [
         "x64"
       ],
@@ -1072,13 +1105,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.1.0"
+        "@img/sharp-libvips-linux-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.2.tgz",
-      "integrity": "sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
       "cpu": [
         "arm64"
       ],
@@ -1094,13 +1127,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.2.tgz",
-      "integrity": "sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
       "cpu": [
         "x64"
       ],
@@ -1116,20 +1149,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.2.tgz",
-      "integrity": "sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
       "cpu": [
         "wasm32"
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.4.3"
+        "@emnapi/runtime": "^1.2.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1139,9 +1172,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.2.tgz",
-      "integrity": "sha512-cfP/r9FdS63VA5k0xiqaNaEoGxBg9k7uE+RQGzuK9fHt7jib4zAVVseR9LsE4gJcNWgT6APKMNnCcnyOtmSEUQ==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
+      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
       "cpu": [
         "arm64"
       ],
@@ -1158,9 +1191,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.2.tgz",
-      "integrity": "sha512-QLjGGvAbj0X/FXl8n1WbtQ6iVBpWU7JO94u/P2M4a8CFYsvQi4GW2mRy/JqkRx0qpBzaOdKJKw8uc930EX2AHw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
       "cpu": [
         "ia32"
       ],
@@ -1177,9 +1210,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.2.tgz",
-      "integrity": "sha512-aUdT6zEYtDKCaxkofmmJDJYGCf0+pJg3eU9/oBuqvEeoB9dKI6ZLc/1iLJCTuJQDO4ptntAlkUmHgGjyuobZbw==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
       "cpu": [
         "x64"
       ],
@@ -3790,7 +3823,6 @@
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -3822,7 +3854,6 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -4160,11 +4191,10 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6110,8 +6140,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -8064,6 +8093,367 @@
         }
       }
     },
+    "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
+      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
+      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
+      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
+      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
+      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
+      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
+      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
+      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
+      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
+      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
+      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
+      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
+      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
+      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
+      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.5.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
+      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
+      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -8090,6 +8480,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/next/node_modules/sharp": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
+      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.4",
+        "@img/sharp-darwin-x64": "0.34.4",
+        "@img/sharp-libvips-darwin-arm64": "1.2.3",
+        "@img/sharp-libvips-darwin-x64": "1.2.3",
+        "@img/sharp-libvips-linux-arm": "1.2.3",
+        "@img/sharp-libvips-linux-arm64": "1.2.3",
+        "@img/sharp-libvips-linux-ppc64": "1.2.3",
+        "@img/sharp-libvips-linux-s390x": "1.2.3",
+        "@img/sharp-libvips-linux-x64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
+        "@img/sharp-linux-arm": "0.34.4",
+        "@img/sharp-linux-arm64": "0.34.4",
+        "@img/sharp-linux-ppc64": "0.34.4",
+        "@img/sharp-linux-s390x": "0.34.4",
+        "@img/sharp-linux-x64": "0.34.4",
+        "@img/sharp-linuxmusl-arm64": "0.34.4",
+        "@img/sharp-linuxmusl-x64": "0.34.4",
+        "@img/sharp-wasm32": "0.34.4",
+        "@img/sharp-win32-arm64": "0.34.4",
+        "@img/sharp-win32-ia32": "0.34.4",
+        "@img/sharp-win32-x64": "0.34.4"
       }
     },
     "node_modules/node-domexception": {
@@ -9519,7 +9952,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9596,16 +10028,15 @@
       "license": "MIT"
     },
     "node_modules/sharp": {
-      "version": "0.34.2",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
-      "integrity": "sha512-lszvBmB9QURERtyKT2bNmsgxXK0ShJrL/fvqlonCo7e6xBF8nT8xU6pW+PMIbLsz0RxQk3rgH9kd8UmvOzlMJg==",
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "color": "^4.2.3",
-        "detect-libc": "^2.0.4",
-        "semver": "^7.7.2"
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -9614,27 +10045,25 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.2",
-        "@img/sharp-darwin-x64": "0.34.2",
-        "@img/sharp-libvips-darwin-arm64": "1.1.0",
-        "@img/sharp-libvips-darwin-x64": "1.1.0",
-        "@img/sharp-libvips-linux-arm": "1.1.0",
-        "@img/sharp-libvips-linux-arm64": "1.1.0",
-        "@img/sharp-libvips-linux-ppc64": "1.1.0",
-        "@img/sharp-libvips-linux-s390x": "1.1.0",
-        "@img/sharp-libvips-linux-x64": "1.1.0",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
-        "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
-        "@img/sharp-linux-arm": "0.34.2",
-        "@img/sharp-linux-arm64": "0.34.2",
-        "@img/sharp-linux-s390x": "0.34.2",
-        "@img/sharp-linux-x64": "0.34.2",
-        "@img/sharp-linuxmusl-arm64": "0.34.2",
-        "@img/sharp-linuxmusl-x64": "0.34.2",
-        "@img/sharp-wasm32": "0.34.2",
-        "@img/sharp-win32-arm64": "0.34.2",
-        "@img/sharp-win32-ia32": "0.34.2",
-        "@img/sharp-win32-x64": "0.34.2"
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
       }
     },
     "node_modules/shebang-command": {
@@ -9747,7 +10176,6 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "18.2.0",
     "speakeasy": "^2.0.0",
+    "sharp": "^0.33.4",
     "tailwindcss": "^3.4.1",
     "tesseract.js": "^6.0.1",
     "ts-node": "^10.9.2",

--- a/pages/api/admin/health.ts
+++ b/pages/api/admin/health.ts
@@ -1,0 +1,64 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { OpenAI } from 'openai';
+import { RAG_CONFIG } from '../../../lib/rag/config';
+import { supabaseAdmin } from '../../../lib/server/supabaseAdmin';
+
+const isPublicAdminEnabled = () =>
+  process.env.NEXT_PUBLIC_PUBLIC_ADMIN === 'true' || process.env.PUBLIC_ADMIN === 'true';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!isPublicAdminEnabled()) {
+    return res.status(403).json({ error: 'disabled' });
+  }
+
+  try {
+    const [documentsResp, chunksResp] = await Promise.all([
+      supabaseAdmin.from('documents_metadata').select('id', { count: 'exact', head: true }),
+      supabaseAdmin.from('document_chunks').select('id', { count: 'exact', head: true }),
+    ]);
+
+    const documents_count = documentsResp?.count ?? 0;
+    const chunks_count = chunksResp?.count ?? 0;
+
+    let sample_match: any = null;
+    const apiKey = process.env.OPENAI_API_KEY;
+
+    if (apiKey) {
+      try {
+        const client = new OpenAI({ apiKey });
+        const embeddingResponse = await client.embeddings.create({
+          model: RAG_CONFIG.embeddingModel,
+          input: 'health check query',
+        });
+        const embedding = embeddingResponse.data?.[0]?.embedding;
+
+        if (embedding) {
+          const { data, error } = await supabaseAdmin.rpc('match_documents', {
+            query_embedding: embedding,
+            similarity_threshold: RAG_CONFIG.similarityThreshold,
+            match_count: 1,
+          });
+
+          if (!error) {
+            sample_match = data?.[0] ?? null;
+          }
+        }
+      } catch (error) {
+        console.warn('admin health embedding failed', error);
+      }
+    }
+
+    if (!sample_match) {
+      const { data } = await supabaseAdmin
+        .from('document_chunks')
+        .select('doc_id, chunk_index, content')
+        .limit(1);
+      sample_match = data?.[0] ?? null;
+    }
+
+    res.status(200).json({ documents_count, chunks_count, sample_match });
+  } catch (error: any) {
+    console.error('admin health error', error);
+    res.status(500).json({ error: 'health check failed', detail: error?.message ?? String(error) });
+  }
+}

--- a/pages/api/cron/process-unindexed-documents.ts
+++ b/pages/api/cron/process-unindexed-documents.ts
@@ -183,7 +183,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             pipeline.processDocument(metadata, {
               chunkSize: RAG_CONFIG.chunkSize,
               chunkOverlap: RAG_CONFIG.chunkOverlap,
-              skipExisting: false,
             })
           );
         } finally {

--- a/pages/api/process-document.ts
+++ b/pages/api/process-document.ts
@@ -186,7 +186,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await pipeline.processDocument(document, {
       chunkSize: RAG_CONFIG.chunkSize,
       chunkOverlap: RAG_CONFIG.chunkOverlap,
-      skipExisting: false,
     });
 
     // Get chunk count after processing

--- a/pages/api/test-rag-pipeline.ts
+++ b/pages/api/test-rag-pipeline.ts
@@ -83,12 +83,11 @@ async function processTestDocument(documentId: string, res: NextApiResponse) {
     // Initialize RAG pipeline
     const pipeline = new RAGPipeline(supabase, openaiApiKey);
 
-    // Process the document
-    await pipeline.processDocument(document, {
-      chunkSize: RAG_CONFIG.chunkSize,
-      chunkOverlap: RAG_CONFIG.chunkOverlap,
-      skipExisting: false
-    });
+  // Process the document
+  await pipeline.processDocument(document, {
+    chunkSize: RAG_CONFIG.chunkSize,
+    chunkOverlap: RAG_CONFIG.chunkOverlap
+  });
 
     // Verify chunks were created
     const { data: chunks, error: chunksError } = await supabaseAdmin

--- a/scripts/process-all-pending-documents.js
+++ b/scripts/process-all-pending-documents.js
@@ -17,176 +17,338 @@ if (_undici) {
 require('ts-node').register({ transpileOnly: true, compilerOptions: { module: 'commonjs' } });
 require('dotenv').config({ path: '.env.local' });
 
-// ---- imports ----
+const path = require('path');
 const { createClient } = require('@supabase/supabase-js');
+const { RAGPipeline } = require('../lib/rag/pipeline');
+const { RAG_CONFIG, openaiApiKey } = require('../lib/rag/config');
+const { extractText } = require('../lib/rag/extract-text');
+const { RetryableError, isRetryableError } = require('../lib/rag/errors');
 
-// ✅ Let op de .ts extensies hieronder (je roept aan vanuit een .js script)
-const { RAGPipeline } = require('../lib/rag/pipeline.ts');
-const { RAG_CONFIG, openaiApiKey } = require('../lib/rag/config.ts');
-const { extractText } = require('../lib/rag/extract-text.ts');
+const args = process.argv.slice(2);
+const FORCE = args.includes('--force');
+const DRY_RUN = args.includes('--dry-run');
+const limitArg = args.find((arg) => arg.startsWith('--limit='));
+const LIMIT = limitArg ? Number.parseInt(limitArg.split('=')[1], 10) : undefined;
 
-// ---- config ----
-const CONFIG = {
-  SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
-  SUPABASE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
-  BATCH_SIZE: 10,
-  CONCURRENCY: 3,
-  DELAY_MS: 2000,
-};
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const DOCUMENTS_BUCKET = process.env.SUPABASE_DOCUMENTS_BUCKET || RAG_CONFIG.documentsBucket;
 
-if (!CONFIG.SUPABASE_URL || !CONFIG.SUPABASE_KEY) {
+if (!SUPABASE_URL || !SUPABASE_KEY) {
   console.error('❌ Missing Supabase credentials. Please check your .env.local file.');
   process.exit(1);
 }
 
-const supabaseAdmin = createClient(CONFIG.SUPABASE_URL, CONFIG.SUPABASE_KEY);
+if (!DOCUMENTS_BUCKET) {
+  console.error('❌ SUPABASE_DOCUMENTS_BUCKET environment variable is required.');
+  process.exit(1);
+}
+
+const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_KEY);
 const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
 
-// Global handler to ensure unhandled promise rejections don't go silent
 process.on('unhandledRejection', (err) => {
   console.error('Unhandled rejection:', err);
   process.exit(1);
 });
 
-async function withTimeout(promise, ms = 60_000) {
-  return await Promise.race([
-    promise,
-    new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), ms)),
-  ]);
-}
+const summary = { ok: true, total: 0, processed_ok: 0, needs_ocr: 0, retried: 0, failed: 0 };
 
-const summary = { total: 0, processed_ok: 0, needs_ocr: 0, retried: 0, failed: 0 };
+const IGNORED_FILENAMES = new Set(['thumbs.db']);
+const UNSUPPORTED_EXTENSIONS = new Set(['.zip', '.nlbl']);
 
-async function main() {
-  try {
-    const { data: documents, error } = await supabaseAdmin
-      .from('documents_metadata')
-      .select('*')
-      .eq('ready_for_indexing', true)
-      .eq('processed', false)
-      .order('last_updated', { ascending: true });
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    if (error) throw new Error(`Failed to fetch documents: ${error.message}`);
+async function fetchPendingDocuments() {
+  let query = supabaseAdmin
+    .from('documents_metadata')
+    .select('*')
+    .eq('ready_for_indexing', true)
+    .order('last_updated', { ascending: true });
 
-    if (!documents || documents.length === 0) {
-      console.log('✅ No documents to process');
-      console.log(
-        JSON.stringify({ ok: true, total: 0, processed_ok: 0, needs_ocr: 0, retried: 0, failed: 0 })
-      );
-      process.exit(0);
-    }
-
-    summary.total = documents.length;
-    const batches = chunkArray(documents, CONFIG.BATCH_SIZE);
-
-    for (let i = 0; i < batches.length; i++) {
-      const batch = batches[i];
-      console.log(`\n🔄 Processing batch ${i + 1}/${batches.length} (${batch.length} docs)`);
-      try {
-        await processBatch(batch, CONFIG.CONCURRENCY);
-      } catch (err) {
-        console.error(
-          `❌ Batch ${i + 1} failed:`,
-          err && err.message ? err.message : err
-        );
-      }
-      if (i < batches.length - 1) await delay(CONFIG.DELAY_MS);
-    }
-
-    console.log(JSON.stringify({ ok: true, ...summary }));
-    process.exit(0);
-  } catch (err) {
-    console.error('❌ Fatal error:', err && err.message ? err.message : err);
-    process.exit(1);
+  if (!FORCE) {
+    query = query.eq('processed', false);
   }
-}
 
-function chunkArray(arr, size) {
-  const chunks = [];
-  for (let i = 0; i < arr.length; i += size) chunks.push(arr.slice(i, i + size));
-  return chunks;
-}
-
-async function delay(ms) {
-  return new Promise((res) => setTimeout(res, ms));
-}
-
-async function processBatch(docs, concurrency) {
-  const executing = [];
-  for (const doc of docs) {
-    const p = processDocument(doc).finally(() => {
-      const idx = executing.indexOf(p);
-      if (idx > -1) executing.splice(idx, 1);
-    });
-    executing.push(p);
-    if (executing.length >= concurrency) await Promise.race(executing);
+  if (typeof LIMIT === 'number' && !Number.isNaN(LIMIT)) {
+    query = query.limit(LIMIT);
   }
-  await Promise.all(executing);
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(`Failed to fetch documents: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+function shouldSkipDocument(document) {
+  const filename = (document.filename || '').toLowerCase();
+  if (IGNORED_FILENAMES.has(filename)) {
+    return { skip: true, lastError: 'ignored-system-file', result: 'ignored-system-file' };
+  }
+  const ext = path.extname(filename);
+  if (UNSUPPORTED_EXTENSIONS.has(ext)) {
+    return { skip: true, lastError: 'unsupported-archive', result: 'unsupported-archive' };
+  }
+  return { skip: false };
+}
+
+function classifyError(error) {
+  const status = error?.status ?? error?.statusCode ?? error?.response?.status ?? error?.code;
+  const retryable = Boolean(
+    isRetryableError(error) ||
+      status === 429 ||
+      (typeof status === 'number' && status >= 500) ||
+      (error?.message && /timeout/i.test(error.message))
+  );
+
+  const message = error?.message || (typeof error === 'string' ? error : 'unknown-error');
+  return { retryable, status, message };
+}
+
+async function updateDocument(id, patch) {
+  if (DRY_RUN) {
+    console.log(`📝 [dry-run] would update document ${id}`, patch);
+    return;
+  }
+
+  const update = { ...patch, last_updated: new Date().toISOString() };
+  const { error } = await supabaseAdmin.from('documents_metadata').update(update).eq('id', id);
+  if (error) {
+    throw error;
+  }
 }
 
 async function processDocument(document) {
+  const logEntry = {
+    id: document.id,
+    filename: document.filename,
+    mime: document.mime_type || null,
+    kind: null,
+    text_len: 0,
+    chunks: 0,
+    result: '',
+    error: null,
+    retry_count: document.retry_count || 0,
+  };
+
   try {
+    const skipInfo = shouldSkipDocument(document);
+    if (skipInfo.skip) {
+      await updateDocument(document.id, {
+        processed: false,
+        processed_at: null,
+        needs_ocr: false,
+        last_error: skipInfo.lastError,
+        chunk_count: 0,
+      });
+
+      logEntry.result = skipInfo.result;
+      logEntry.error = skipInfo.lastError;
+      summary.failed += 1;
+      return logEntry;
+    }
+
+    const bucket = document.bucket || DOCUMENTS_BUCKET;
     const { data: fileData, error: downloadError } = await supabaseAdmin.storage
-      .from('company-docs') // bucket
+      .from(bucket)
       .download(document.storage_path);
-    if (downloadError) throw new Error(`Failed to download: ${downloadError.message}`);
+
+    if (downloadError) {
+      const status = downloadError?.statusCode || downloadError?.status || 'unknown';
+      const message = downloadError?.message || 'download-error';
+      const lastError = `download-failed:${status}:${message}`;
+      await updateDocument(document.id, {
+        processed: false,
+        processed_at: null,
+        last_error: lastError,
+      });
+
+      logEntry.result = 'download-failed';
+      logEntry.error = lastError;
+      summary.failed += 1;
+      return logEntry;
+    }
 
     const buffer = Buffer.from(await fileData.arrayBuffer());
-    const { kind, mime, text } = await extractText(buffer, document.filename);
-    const textLen = (text || '').trim().length;
-    if (kind === 'pdf-scan' || kind === 'unknown' || textLen === 0) {
-      const reason = kind === 'unknown' ? 'unknown-mime' : 'needs-ocr-scan';
-      await supabaseAdmin
-        .from('documents_metadata')
-        .update({ processed: false, processed_at: null, needs_ocr: true, chunk_count: 0, last_error: reason })
-        .eq('id', document.id);
-      summary.needs_ocr++;
-      console.log(`[${document.id}] ${document.filename} | ${mime} | kind=${kind} | text_len=${textLen} | result=${reason}`);
-      return;
+    const extracted = await extractText(buffer, document.filename);
+
+    logEntry.kind = extracted.kind;
+    logEntry.mime = extracted.mime || logEntry.mime;
+    logEntry.text_len = extracted.text.length;
+
+    if (extracted.text.length === 0) {
+      const lastError = extracted.usedOcr ? 'ocr-failed' : 'needs-ocr';
+      await updateDocument(document.id, {
+        processed: false,
+        processed_at: null,
+        needs_ocr: true,
+        last_error: lastError,
+        chunk_count: 0,
+      });
+
+      logEntry.result = lastError;
+      logEntry.error = lastError;
+      summary.needs_ocr += 1;
+      return logEntry;
     }
 
-    const extractedText = text;
-    let chunkCount = 0;
-    try {
-      const metadata = { ...document, extractedText };
-      chunkCount = await withTimeout(
-        pipeline.processDocument(metadata, {
-          chunkSize: RAG_CONFIG.chunkSize,
-          chunkOverlap: RAG_CONFIG.chunkOverlap,
-          skipExisting: false,
-        })
-      );
+    const metadata = {
+      ...document,
+      bucket,
+      mime_type: extracted.mime || document.mime_type,
+      extractedText: extracted.text,
+    };
 
-      await supabaseAdmin
-        .from('documents_metadata')
-        .update({ processed: true, processed_at: new Date().toISOString(), chunk_count: chunkCount, last_error: null })
-        .eq('id', document.id);
+    const chunkCount = await runPipelineWithRetries(metadata, logEntry);
+    logEntry.chunks = chunkCount;
 
-      summary.processed_ok++;
-      console.log(`[${document.id}] ${document.filename} | ${mime} | kind=${kind} | text_len=${textLen} | chunks=${chunkCount}`);
-    } catch (err) {
-      const msg = err && err.message ? err.message : String(err);
-      const isOpenAIError = (err && err.name && String(err.name).includes('OpenAI')) || err?.status === 429;
+    await updateDocument(document.id, {
+      processed: true,
+      processed_at: new Date().toISOString(),
+      needs_ocr: false,
+      last_error: null,
+      chunk_count: chunkCount,
+      retry_count: 0,
+      mime_type: metadata.mime_type,
+      bucket,
+    });
 
-      const update = isOpenAIError
-        ? { last_error: `Processing failed: ${msg}`, retry_count: (document.retry_count || 0) + 1 }
-        : { processed: true, processed_at: new Date().toISOString(), last_error: `Processing failed: ${msg}`, chunk_count: 0 };
+    logEntry.result = 'processed';
+    summary.processed_ok += 1;
+    return logEntry;
+  } catch (error) {
+    const { message } = classifyError(error);
+    await updateDocument(document.id, {
+      processed: false,
+      processed_at: null,
+      last_error: message,
+    });
 
-      await supabaseAdmin.from('documents_metadata').update(update).eq('id', document.id);
-
-      if (isOpenAIError) {
-        summary.retried++;
-        console.log(`[${document.id}] ${document.filename} | ${mime} | kind=${kind} | text_len=${textLen} | result=retry`);
-      } else {
-        summary.failed++;
-        console.log(`[${document.id}] ${document.filename} | ${mime} | kind=${kind} | text_len=${textLen} | result=fail`);
-      }
-    }
-  } catch (err) {
-    const msg = err && err.message ? err.message : String(err);
-    summary.failed++;
-    console.log(`[${document.id}] ${document.filename} | result=fatal-${msg}`);
+    logEntry.result = 'failed';
+    logEntry.error = message;
+    summary.failed += 1;
+    return logEntry;
   }
 }
 
-main();
+async function runPipelineWithRetries(metadata, logEntry) {
+  let attempt = 0;
+  let retryCount = logEntry.retry_count || 0;
+  let countedRetry = false;
+  const maxRetries = RAG_CONFIG.retryMax;
+  let lastError = null;
+
+  while (attempt <= maxRetries) {
+    try {
+      const chunkCount = await pipeline.processDocument(
+        metadata,
+        {
+          chunkSize: RAG_CONFIG.chunkSize,
+          chunkOverlap: RAG_CONFIG.chunkOverlap,
+          dryRun: DRY_RUN,
+        },
+        { dryRun: DRY_RUN }
+      );
+      return chunkCount;
+    } catch (error) {
+      const { retryable, message } = classifyError(error);
+      lastError = message;
+
+      if (!retryable || attempt >= maxRetries) {
+        if (retryable && attempt >= maxRetries) {
+          await updateDocument(metadata.id, {
+            processed: false,
+            processed_at: null,
+            last_error: 'retry-exhausted',
+          });
+          logEntry.error = 'retry-exhausted';
+          throw new RetryableError('retry-exhausted', error);
+        }
+        throw error;
+      }
+
+      attempt += 1;
+      retryCount += 1;
+      logEntry.retry_count = retryCount;
+      if (!countedRetry) {
+        summary.retried += 1;
+        countedRetry = true;
+      }
+
+      await updateDocument(metadata.id, {
+        processed: false,
+        processed_at: null,
+        last_error: message,
+        retry_count: retryCount,
+      });
+
+      const delay = Math.min(60000, Math.pow(2, attempt) * 1000);
+      await sleep(delay);
+    }
+  }
+
+  throw new RetryableError(lastError || 'retry-exhausted');
+}
+
+async function processDocuments(documents) {
+  const concurrency = Math.max(1, RAG_CONFIG.concurrency || 2);
+  const delayMs = Math.max(0, RAG_CONFIG.delayMs || 0);
+  const executing = new Set();
+
+  for (const document of documents) {
+    const task = (async () => {
+      const result = await processDocument(document);
+      console.log(JSON.stringify(result));
+    })().finally(() => executing.delete(task));
+
+    executing.add(task);
+    if (executing.size >= concurrency) {
+      await Promise.race(executing);
+    }
+
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  await Promise.all(executing);
+}
+
+async function main() {
+  try {
+    const documents = await fetchPendingDocuments();
+    if (!documents.length) {
+      console.log(JSON.stringify(summary));
+      return summary;
+    }
+
+    summary.total = documents.length;
+    await processDocuments(documents);
+
+    console.log(JSON.stringify(summary));
+    return summary;
+  } catch (error) {
+    console.error('❌ Fatal error:', error?.message || error);
+    summary.ok = false;
+    console.log(JSON.stringify(summary));
+    process.exitCode = 1;
+    return summary;
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('❌ Unhandled error:', error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  main,
+  shouldSkipDocument,
+  classifyError,
+  processDocument,
+  runPipelineWithRetries,
+};

--- a/sql/bootstrap.sql
+++ b/sql/bootstrap.sql
@@ -30,6 +30,7 @@ create table if not exists documents_metadata (
   id uuid primary key default gen_random_uuid(),
   filename text not null,
   storage_path text not null,
+  bucket text null,
   mime_type text null,
   ready_for_indexing boolean not null default false,
   processed boolean not null default false,
@@ -53,6 +54,7 @@ create table if not exists document_chunks (
 );
 
 create index if not exists document_chunks_doc_id_idx on document_chunks(doc_id);
+create unique index if not exists document_chunks_doc_id_chunk_index_idx on document_chunks(doc_id, chunk_index);
 create index if not exists document_chunks_gin on document_chunks using ivfflat (embedding);
 
 -- Similarity search helper

--- a/tests/api/chat.test.ts
+++ b/tests/api/chat.test.ts
@@ -1,42 +1,146 @@
-import handler from '../../pages/api/chat.ts';
 import { createMocks } from 'node-mocks-http';
 
-var insertMock: jest.Mock;
-var fromMock: jest.Mock;
-jest.mock('../../lib/supabaseClient', () => {
-  insertMock = jest.fn().mockResolvedValue({});
-  fromMock = jest.fn(() => ({ insert: insertMock }));
-  return { supabase: { from: fromMock } };
+type SupabaseMockModule = {
+  supabaseAdmin: { from: jest.Mock };
+  __mocks: {
+    fromMock: jest.Mock;
+    selectSessionMock: jest.Mock;
+    maybeSingleMock: jest.Mock;
+    insertSessionMock: jest.Mock;
+    insertMessageMock: jest.Mock;
+    singleMock: jest.Mock;
+  };
+};
+
+type PipelineMockModule = {
+  RAGPipeline: jest.Mock;
+  __mocks: {
+    searchSimilarDocuments: jest.Mock;
+  };
+};
+
+type OpenAIMockModule = {
+  OpenAI: jest.Mock;
+  __mocks: {
+    createCompletion: jest.Mock;
+  };
+};
+
+jest.mock('../../lib/server/supabaseAdmin', () => {
+  const maybeSingleMock = jest.fn().mockResolvedValue({ data: null, error: null });
+  const selectSessionMock = jest.fn(() => ({
+    eq: jest.fn(() => ({ maybeSingle: maybeSingleMock })),
+  }));
+
+  const singleMock = jest.fn().mockResolvedValue({
+    data: { id: 'session-id' },
+    error: null,
+  });
+
+  const insertSessionMock = jest.fn(() => ({
+    select: jest.fn(() => ({ single: singleMock })),
+  }));
+
+  const insertMessageMock = jest.fn().mockResolvedValue({ data: null, error: null });
+
+  const fromMock = jest.fn((table: string) => {
+    if (table === 'chat_sessions') {
+      return {
+        select: selectSessionMock,
+        insert: insertSessionMock,
+      };
+    }
+
+    if (table === 'chat_messages') {
+      return {
+        insert: insertMessageMock,
+      };
+    }
+
+    return {};
+  });
+
+  return {
+    supabaseAdmin: { from: fromMock },
+    __mocks: {
+      fromMock,
+      selectSessionMock,
+      maybeSingleMock,
+      insertSessionMock,
+      insertMessageMock,
+      singleMock,
+    },
+  } satisfies SupabaseMockModule;
 });
 
-var searchSimilarDocuments: jest.Mock;
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: jest.fn(() => ({ select: jest.fn(), eq: jest.fn() })),
+  })),
+}));
+
 jest.mock('../../lib/rag/pipeline', () => {
-  searchSimilarDocuments = jest.fn();
+  const searchSimilarDocuments = jest.fn();
   return {
     RAGPipeline: jest.fn().mockImplementation(() => ({
       searchSimilarDocuments,
     })),
-  };
+    __mocks: { searchSimilarDocuments },
+  } satisfies PipelineMockModule;
 });
 
-var createCompletion: jest.Mock;
 jest.mock('openai', () => {
-  createCompletion = jest.fn().mockResolvedValue({
+  const createCompletion = jest.fn().mockResolvedValue({
     choices: [{ message: { content: 'Test response' } }],
   });
   return {
     OpenAI: jest.fn().mockImplementation(() => ({
       chat: { completions: { create: createCompletion } },
     })),
-  };
+    __mocks: { createCompletion },
+  } satisfies OpenAIMockModule;
 });
 
-jest.mock('../../lib/rag/config', () => ({ openaiApiKey: 'test-key' }));
+jest.mock('../../lib/rag/config', () => ({
+  openaiApiKey: 'test-key',
+  RAG_CONFIG: { maxResults: 3 },
+}));
+
+const {
+  __mocks: {
+    fromMock,
+    selectSessionMock,
+    maybeSingleMock,
+    insertSessionMock,
+    insertMessageMock,
+    singleMock,
+  },
+} = jest.requireMock('../../lib/server/supabaseAdmin') as SupabaseMockModule;
+
+const {
+  __mocks: { searchSimilarDocuments },
+} = jest.requireMock('../../lib/rag/pipeline') as PipelineMockModule;
+
+const {
+  __mocks: { createCompletion },
+} = jest.requireMock('openai') as OpenAIMockModule;
+
+const handler = require('../../pages/api/chat.ts').default;
 
 describe('chat API', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon';
+    process.env.OPENAI_API_KEY = 'test';
+  });
+
   beforeEach(() => {
-    insertMock.mockClear();
     fromMock.mockClear();
+    selectSessionMock.mockClear();
+    maybeSingleMock.mockClear();
+    insertSessionMock.mockClear();
+    insertMessageMock.mockClear();
+    singleMock.mockClear();
     searchSimilarDocuments.mockReset();
     createCompletion.mockClear();
   });
@@ -54,19 +158,20 @@ describe('chat API', () => {
   });
 
   it('returns reply and sources on success', async () => {
-    searchSimilarDocuments.mockResolvedValue([{ content: 'Doc', metadata: {}, similarity: 0.9 }]);
-    const { req, res } = createMocks({ method: 'POST', body: { prompt: 'Hi' } });
+    searchSimilarDocuments.mockResolvedValue([
+      { content: 'Doc', metadata: {}, similarity: 0.9 },
+    ]);
+    const { req, res } = createMocks({ method: 'POST', body: { message: 'Hi' } });
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
-    expect(data.reply).toBe('Test response');
-    expect(data.modelUsed).toBeDefined();
+    expect(data.answer).toBe('Test response');
     expect(Array.isArray(data.sources)).toBe(true);
   });
 
   it('handles pipeline errors gracefully', async () => {
     searchSimilarDocuments.mockRejectedValue(new Error('boom'));
-    const { req, res } = createMocks({ method: 'POST', body: { prompt: 'Hi' } });
+    const { req, res } = createMocks({ method: 'POST', body: { message: 'Hi' } });
     await handler(req, res);
     expect(res._getStatusCode()).toBe(500);
   });

--- a/tests/rag/ingest-behaviour.test.ts
+++ b/tests/rag/ingest-behaviour.test.ts
@@ -1,0 +1,123 @@
+import type { TextChunk } from '../../lib/rag/types';
+
+jest.mock('file-type', () => ({
+  fileTypeFromBuffer: jest.fn(),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: jest.fn(() => ({
+      select: jest.fn(),
+      eq: jest.fn(),
+      order: jest.fn(),
+      limit: jest.fn(),
+    })),
+    storage: { from: jest.fn(() => ({ download: jest.fn() })) },
+  })),
+}));
+
+jest.mock('../../lib/rag/pipeline', () => ({
+  RAGPipeline: jest.fn().mockImplementation(() => ({ processDocument: jest.fn() })),
+}));
+
+const sharpToBufferMock = jest.fn();
+const sharpMetadataMock = jest.fn().mockResolvedValue({ pages: 1 });
+
+jest.mock('sharp', () => {
+  const chain = {
+    ensureAlpha: jest.fn().mockReturnThis(),
+    grayscale: jest.fn().mockReturnThis(),
+    toFormat: jest.fn().mockReturnThis(),
+    toBuffer: sharpToBufferMock,
+    metadata: sharpMetadataMock,
+  };
+  const sharpFn = jest.fn(() => chain);
+  sharpFn.default = sharpFn;
+  return sharpFn;
+});
+
+const recognizeMock = jest.fn();
+const terminateMock = jest.fn();
+
+jest.mock('tesseract.js', () => ({
+  createWorker: jest.fn(async () => ({ recognize: recognizeMock, terminate: terminateMock })),
+}));
+
+describe('ingest behaviour', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sharpToBufferMock.mockResolvedValue(Buffer.from('image'));
+    recognizeMock.mockResolvedValue({ data: { text: '  OCR tekst  ' } });
+    terminateMock.mockResolvedValue(undefined);
+    sharpMetadataMock.mockResolvedValue({ pages: 1 });
+  });
+
+  it('uses OCR pipeline for images', async () => {
+    const { fileTypeFromBuffer } = await import('file-type');
+    (fileTypeFromBuffer as jest.Mock).mockResolvedValue({ mime: 'image/png' });
+
+    const { extractText } = await import('../../lib/rag/extract-text');
+    const result = await extractText(Buffer.from('dummy'), 'foto.png');
+
+    expect(result.usedOcr).toBe(true);
+    expect(result.ocrAttempted).toBe(true);
+    expect(result.text).toBe('OCR tekst');
+
+    const { createWorker } = await import('tesseract.js');
+    expect((createWorker as jest.Mock)).toHaveBeenCalledWith('nld+eng');
+    expect(recognizeMock).toHaveBeenCalled();
+    expect(terminateMock).toHaveBeenCalled();
+  });
+
+  it('skips unsupported and system files', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+    process.env.SUPABASE_DOCUMENTS_BUCKET = 'bucket';
+    process.env.OPENAI_API_KEY = 'test-key';
+
+    const module = await import('../../scripts/process-all-pending-documents.js');
+    const { shouldSkipDocument } = module;
+
+    expect(shouldSkipDocument({ filename: 'Thumbs.db' } as any)).toEqual(
+      expect.objectContaining({ skip: true, lastError: 'ignored-system-file' })
+    );
+    expect(shouldSkipDocument({ filename: 'document.zip' } as any)).toEqual(
+      expect.objectContaining({ skip: true, lastError: 'unsupported-archive' })
+    );
+    expect(shouldSkipDocument({ filename: 'report.nlbl' } as any)).toEqual(
+      expect.objectContaining({ skip: true, lastError: 'unsupported-archive' })
+    );
+  });
+
+  it('upserts document chunks idempotently', async () => {
+    const upsertMock = jest.fn().mockResolvedValue({ error: null });
+    const gtMock = jest.fn().mockResolvedValue({ error: null });
+    const eqMock = jest.fn(() => ({ gt: gtMock }));
+    const deleteMock = jest.fn(() => ({ eq: eqMock }));
+    const fromMock = jest.fn(() => ({ upsert: upsertMock, delete: deleteMock }));
+
+    const supabase = { from: fromMock } as any;
+
+    const { VectorStore } = await import('../../lib/rag/vectorStore');
+    const store = new VectorStore(supabase as any);
+    const chunks: TextChunk[] = [
+      { docId: 'doc', chunk_index: 0, content: 'A', embedding: Array(1536).fill(0), metadata: {} },
+      { docId: 'doc', chunk_index: 1, content: 'B', embedding: Array(1536).fill(1), metadata: {} },
+    ];
+
+    await store.storeChunks(chunks);
+    await store.storeChunks(chunks);
+
+    expect(upsertMock).toHaveBeenCalledTimes(2);
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ doc_id: 'doc', chunk_index: 0 }),
+        expect.objectContaining({ doc_id: 'doc', chunk_index: 1 }),
+      ]),
+      expect.objectContaining({ onConflict: 'doc_id,chunk_index' })
+    );
+    expect(deleteMock).toHaveBeenCalled();
+    expect(eqMock).toHaveBeenCalledWith('doc_id', 'doc');
+    expect(gtMock).toHaveBeenCalledWith('chunk_index', 1);
+  });
+});

--- a/tests/rag/pipeline.test.ts
+++ b/tests/rag/pipeline.test.ts
@@ -21,7 +21,16 @@ jest.mock('../../lib/rag/vectorStore', () => ({
 }));
 
 jest.mock('../../lib/rag/config', () => ({
-  RAG_CONFIG: { embeddingModel: 'test-embed', similarityThreshold: 0.5, maxResults: 3 }
+  RAG_CONFIG: {
+    embeddingModel: 'test-embed',
+    similarityThreshold: 0.5,
+    maxResults: 3,
+    batchSize: 2,
+    concurrency: 1,
+    delayMs: 0,
+    ocrMinTextLength: 50,
+    retryMax: 2,
+  }
 }));
 
 describe('RAGPipeline', () => {
@@ -45,8 +54,8 @@ describe('RAGPipeline', () => {
 
     const pipeline = new RAGPipeline(supabase, 'key');
     const count = await pipeline.processDocument(
-      { id: 'doc1', filename: 'f' } as any,
-      {} as any
+      { id: 'doc1', filename: 'f', extractedText: 'hello world' } as any,
+      { chunkSize: 100, chunkOverlap: 10 } as any
     );
 
     expect(count).toBe(1);
@@ -60,7 +69,7 @@ describe('RAGPipeline', () => {
 
     const pipeline = new RAGPipeline(supabase, 'key');
     await expect(
-      pipeline.processDocument({ id: 'doc1', filename: 'f' } as any, {} as any)
+      pipeline.processDocument({ id: 'doc1', filename: 'f', extractedText: 'text' } as any, {} as any)
     ).rejects.toThrow('fail');
   });
 


### PR DESCRIPTION
## Summary
- drive ingestion configuration from RAG_* environment variables and expose retry helpers for pipeline components
- harden extract-text OCR workflow and document processing script to support idempotent retries and logging
- add admin health endpoint plus tests for OCR, skip logic, idempotent chunk upserts, and the chat API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbebffb898832b899248b85b481e36