### PR TITLE
Fix RAG schema alignment and add robust RAG processing

### DIFF
--- a/lib/rag/errors.ts
+++ b/lib/rag/errors.ts
@@ -8,6 +8,25 @@ export class RetryableError extends Error {
   }
 }
 
+export class ContentError extends Error {
+  public readonly code: string;
+  public readonly detail?: string;
+
+  constructor(code: string, message?: string, detail?: string) {
+    super(message ?? code);
+    this.name = 'ContentError';
+    this.code = code;
+    this.detail = detail;
+  }
+}
+
+export class NeedsOcrError extends ContentError {
+  constructor(message?: string, detail?: string) {
+    super('needs-ocr', message ?? 'needs-ocr', detail);
+    this.name = 'NeedsOcrError';
+  }
+}
+
 export const isRetryableError = (error: unknown): boolean => {
   if (!error) return false;
   if (error instanceof RetryableError) return true;
@@ -16,3 +35,7 @@ export const isRetryableError = (error: unknown): boolean => {
   }
   return false;
 };
+
+export const isContentError = (error: unknown): error is ContentError => error instanceof ContentError;
+
+export const isNeedsOcrError = (error: unknown): error is NeedsOcrError => error instanceof NeedsOcrError;

--- a/lib/rag/extract-text.ts
+++ b/lib/rag/extract-text.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import sharp from 'sharp';
 import { RAG_CONFIG } from './config';
+import { ContentError, NeedsOcrError } from './errors';
 
 export type ExtractKind =
   | 'pdf'
@@ -25,22 +26,100 @@ export interface ExtractTextResult {
 
 const normaliseText = (text: string) => text?.replace(/\u0000/g, '').trim();
 
+const IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/tiff',
+  'image/tif',
+  'image/bmp',
+  'image/gif',
+]);
+
+const FALLBACK_MIME_BY_EXTENSION: Record<string, string> = {
+  '.txt': 'text/plain',
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.pdf': 'application/pdf',
+};
+
+const MIN_IMAGE_DIMENSION = 32;
+const MIN_IMAGE_BYTES = 2048;
+
+async function validateImageBuffer(buffer: Buffer): Promise<void> {
+  const byteLength = buffer?.length ?? 0;
+  if (!buffer || byteLength === 0) {
+    throw new ContentError('image-empty', 'image buffer empty');
+  }
+
+  try {
+    const metadata = await sharp(buffer).metadata();
+    const width = metadata.width;
+    const height = metadata.height;
+    if (
+      typeof width === 'number' &&
+      typeof height === 'number' &&
+      (width < MIN_IMAGE_DIMENSION || height < MIN_IMAGE_DIMENSION)
+    ) {
+      throw new ContentError('image-too-small', `image-dimensions-too-small:${width}x${height}`);
+    }
+  } catch (error) {
+    if (error instanceof ContentError) {
+      throw error;
+    }
+    const message = (error as Error)?.message ?? 'metadata-error';
+    if (/too small/i.test(message)) {
+      throw new ContentError('image-too-small', message);
+    }
+    throw new NeedsOcrError('ocr-processing-failed', message);
+  }
+}
+
 async function recogniseImages(buffers: Buffer[]): Promise<string> {
   if (!buffers.length) return '';
 
-  const worker = await createWorker('nld+eng');
+  let worker;
+  try {
+    worker = await createWorker('nld+eng');
+  } catch (error) {
+    const message = (error as Error)?.message ?? 'worker-initialisation-failed';
+    throw new NeedsOcrError('ocr-initialisation-failed', message);
+  }
+
   try {
     const pieces: string[] = [];
     for (const buffer of buffers) {
-      const processed = await sharp(buffer).ensureAlpha().grayscale().toFormat('png').toBuffer();
+      await validateImageBuffer(buffer);
+
+      let processed: Buffer;
+      try {
+        processed = await sharp(buffer).ensureAlpha().grayscale().toFormat('png').toBuffer();
+      } catch (error) {
+        if (error instanceof ContentError) {
+          throw error;
+        }
+        const message = (error as Error)?.message ?? 'image-processing-failed';
+        throw new NeedsOcrError('ocr-processing-failed', message);
+      }
+
       const { data } = await worker.recognize(processed);
       if (data?.text) {
         pieces.push(data.text);
       }
     }
+
     return normaliseText(pieces.join('\n\n')) || '';
+  } catch (error) {
+    if (error instanceof NeedsOcrError || error instanceof ContentError) {
+      throw error;
+    }
+    const message = (error as Error)?.message ?? 'ocr-processing-failed';
+    throw new NeedsOcrError('ocr-processing-failed', message);
   } finally {
-    await worker.terminate();
+    if (worker) {
+      await worker.terminate();
+    }
   }
 }
 
@@ -52,17 +131,34 @@ async function ocrPdf(buffer: Buffer): Promise<string> {
     const images: Buffer[] = [];
 
     for (let page = 0; page < pages; page++) {
-      const pageBuffer = await sharp(buffer, { density: 300, page })
-        .grayscale()
-        .toFormat('png')
-        .toBuffer();
-      images.push(pageBuffer);
+      try {
+        const pageBuffer = await sharp(buffer, { density: 300, page })
+          .ensureAlpha()
+          .grayscale()
+          .toFormat('png')
+          .toBuffer();
+        await validateImageBuffer(pageBuffer);
+        images.push(pageBuffer);
+      } catch (error) {
+        if (error instanceof ContentError) {
+          throw error;
+        }
+        const message = (error as Error)?.message ?? 'pdf-ocr-page-failed';
+        throw new NeedsOcrError('ocr-processing-failed', message);
+      }
+    }
+
+    if (!images.length) {
+      throw new NeedsOcrError('ocr-processing-failed', 'pdf-no-pages-rendered');
     }
 
     return await recogniseImages(images);
   } catch (error) {
-    console.error('❌ PDF OCR failed', error);
-    return '';
+    if (error instanceof NeedsOcrError || error instanceof ContentError) {
+      throw error;
+    }
+    const message = (error as Error)?.message ?? 'pdf-ocr-failed';
+    throw new NeedsOcrError('ocr-processing-failed', message);
   }
 }
 
@@ -76,15 +172,14 @@ export async function extractText(
   try {
     const type = await fileTypeFromBuffer(buffer);
     if (type?.mime) detectedMime = type.mime;
-  } catch {}
+  } catch (error) {
+    const message = (error as Error)?.message ?? 'file-type-detection-failed';
+    console.warn(`⚠️ Failed to detect file type for ${filename}: ${message}`);
+  }
 
   const ext = path.extname(filename).toLowerCase();
-  if (!detectedMime) {
-    if (ext === '.txt') detectedMime = 'text/plain';
-    else if (ext === '.md' || ext === '.markdown') detectedMime = 'text/markdown';
-    else if (ext === '.docx') {
-      detectedMime = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-    }
+  if (!detectedMime && ext && FALLBACK_MIME_BY_EXTENSION[ext]) {
+    detectedMime = FALLBACK_MIME_BY_EXTENSION[ext];
   }
 
   switch (detectedMime) {
@@ -105,15 +200,11 @@ export async function extractText(
           usedOcr: true,
         };
       } catch (error) {
-        console.error('❌ PDF parse failed', error);
-        const ocrText = await ocrPdf(buffer);
-        return {
-          kind: 'pdf-scan',
-          mime: detectedMime,
-          text: normaliseText(ocrText) || '',
-          ocrAttempted: true,
-          usedOcr: Boolean(ocrText),
-        };
+        if (error instanceof NeedsOcrError || error instanceof ContentError) {
+          throw error;
+        }
+        const message = (error as Error)?.message ?? 'pdf-parse-failed';
+        throw new NeedsOcrError('ocr-processing-failed', message);
       }
     }
     case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document': {
@@ -122,7 +213,8 @@ export async function extractText(
         const text = normaliseText(docxData.value || '') || '';
         return { kind: 'docx', mime: detectedMime, text, ocrAttempted: false, usedOcr: false };
       } catch (error) {
-        console.error('❌ DOCX parse failed', error);
+        const message = (error as Error)?.message ?? 'docx-parse-failed';
+        console.error('❌ DOCX parse failed', message);
         return { kind: 'docx', mime: detectedMime, text: '', ocrAttempted: false, usedOcr: false };
       }
     }
@@ -134,24 +226,23 @@ export async function extractText(
       const text = normaliseText(buffer.toString('utf-8')) || '';
       return { kind: 'md', mime: detectedMime, text, ocrAttempted: false, usedOcr: false };
     }
-    case 'image/png':
-    case 'image/jpeg':
-    case 'image/jpg':
-    case 'image/tiff':
-    case 'image/tif':
-    case 'image/bmp':
-    case 'image/gif': {
-      const ocrText = await recogniseImages([buffer]);
-      return {
-        kind: 'image',
-        mime: detectedMime,
-        text: normaliseText(ocrText) || '',
-        ocrAttempted: true,
-        usedOcr: true,
-      };
-    }
     default: {
-      return { kind: 'unknown', mime: detectedMime, text: '', ocrAttempted: false, usedOcr: false };
+      if (detectedMime && IMAGE_MIME_TYPES.has(detectedMime)) {
+        const ocrText = await recogniseImages([buffer]);
+        return {
+          kind: 'image',
+          mime: detectedMime,
+          text: normaliseText(ocrText) || '',
+          ocrAttempted: true,
+          usedOcr: true,
+        };
+      }
+
+      if (!detectedMime && ext) {
+        throw new ContentError('unsupported-mime', `unsupported-extension:${ext}`);
+      }
+
+      throw new ContentError('unsupported-mime', detectedMime || 'unknown-mime');
     }
   }
 }

--- a/lib/rag/types.ts
+++ b/lib/rag/types.ts
@@ -13,6 +13,13 @@ export interface DocumentMetadata {
   uploaded_by: string;
   last_updated: string; // ISO-datum als string
   extractedText?: string; // Added field for pre-extracted text
+  processed?: boolean;
+  processed_at?: string | null;
+  needs_ocr?: boolean;
+  chunk_count?: number;
+  retry_count?: number;
+  last_error?: string | null;
+  ready_for_indexing?: boolean;
 }
 
 export type Embedding = number[]; // vector van floats

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "rag:mark-for-indexing": "node scripts/mark-documents-for-indexing.js",
     "rag:process-all": "node scripts/process-all-pending-documents.js",
     "rag:monitor": "node scripts/monitor-rag-status.js",
+    "rag:verify": "node scripts/verify-rag-health.js",
     "rag:health": "next dev -p 3000",
     "bulk-upload": "node scripts/bulk-upload.js",
     "bulk-upload:handleidingen": "node scripts/bulk-upload-handleidingen.js",

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -70,7 +70,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const sources = (results || [])
       .slice(0, RAG_CONFIG.maxResults)
       .map((r: any) => ({
-        doc_id: r.doc_id || r.document_id || null,
+        doc_id: r.doc_id ?? null,
         chunk_index: r.chunk_index ?? null,
         similarity: r.similarity ?? null,
       }));

--- a/scripts/verify-rag-health.js
+++ b/scripts/verify-rag-health.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+/**
+ * RAG health verification
+ *
+ * Ensures the database schema and vector pipeline are aligned and operational.
+ */
+
+const { createClient } = require('@supabase/supabase-js');
+const { EMBEDDING_DIMENSIONS, RAG_CONFIG } = require('../lib/rag/config');
+
+require('dotenv').config({ path: '.env.local' });
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('❌ Missing Supabase credentials (NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY).');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const REQUIRED_METADATA_COLUMNS = [
+  'processed',
+  'processed_at',
+  'needs_ocr',
+  'chunk_count',
+  'retry_count',
+  'last_error',
+  'storage_path',
+  'mime_type',
+  'filename',
+  'ready_for_indexing',
+  'last_updated',
+];
+
+const REQUIRED_CHUNK_COLUMNS = ['id', 'doc_id', 'chunk_index', 'content', 'embedding'];
+
+async function fetchColumnMap() {
+  const { data, error } = await supabase.rpc('sql', {
+    query: `
+      SELECT table_name, column_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name IN ('documents_metadata', 'document_chunks');
+    `,
+  });
+
+  if (error) {
+    throw new Error(`Failed to fetch column metadata: ${error.message}`);
+  }
+
+  const map = new Map();
+  for (const row of data || []) {
+    if (!map.has(row.table_name)) {
+      map.set(row.table_name, new Set());
+    }
+    map.get(row.table_name).add(row.column_name);
+  }
+  return map;
+}
+
+async function fetchCount(table) {
+  const { count, error } = await supabase.from(table).select('*', { count: 'exact', head: true });
+  if (error) {
+    throw new Error(`Failed to count ${table}: ${error.message}`);
+  }
+  return count ?? 0;
+}
+
+async function fetchOrphanChunkCount() {
+  const { data, error } = await supabase.rpc('sql', {
+    query: `
+      SELECT COUNT(*) AS count
+      FROM public.document_chunks dc
+      LEFT JOIN public.documents_metadata dm ON dm.id = dc.doc_id
+      WHERE dm.id IS NULL;
+    `,
+  });
+  if (error) {
+    throw new Error(`Failed to count orphan chunks: ${error.message}`);
+  }
+  const raw = data?.[0]?.count ?? 0;
+  return typeof raw === 'number' ? raw : Number.parseInt(raw, 10) || 0;
+}
+
+async function verifySchemaVisibility() {
+  const { error } = await supabase.from('document_chunks').select('doc_id').limit(1);
+  if (error) {
+    throw new Error(`PostgREST schema cache still outdated: ${error.message}`);
+  }
+}
+
+async function verifyMatchDocuments() {
+  const vector = Array.from({ length: EMBEDDING_DIMENSIONS }, () => 0);
+  const { data, error } = await supabase.rpc('match_documents', {
+    query_embedding: vector,
+    similarity_threshold: RAG_CONFIG.similarityThreshold,
+    match_count: Math.max(1, RAG_CONFIG.maxResults || 5),
+  });
+  if (error) {
+    throw new Error(`match_documents RPC failed: ${error.message}`);
+  }
+  return Array.isArray(data) ? data.length : 0;
+}
+
+async function main() {
+  const report = {
+    metadataColumnsMissing: [],
+    chunkColumnsMissing: [],
+    documentsCount: 0,
+    chunksCount: 0,
+    orphanChunks: 0,
+    schemaVisible: false,
+    matchDocumentsResults: 0,
+  };
+
+  try {
+    const columnMap = await fetchColumnMap();
+    const metadataColumns = columnMap.get('documents_metadata') || new Set();
+    const chunkColumns = columnMap.get('document_chunks') || new Set();
+
+    report.metadataColumnsMissing = REQUIRED_METADATA_COLUMNS.filter((col) => !metadataColumns.has(col));
+    report.chunkColumnsMissing = REQUIRED_CHUNK_COLUMNS.filter((col) => !chunkColumns.has(col));
+
+    report.documentsCount = await fetchCount('documents_metadata');
+    report.chunksCount = await fetchCount('document_chunks');
+    report.orphanChunks = await fetchOrphanChunkCount();
+
+    await verifySchemaVisibility();
+    report.schemaVisible = true;
+
+    report.matchDocumentsResults = await verifyMatchDocuments();
+  } catch (error) {
+    console.error('❌ RAG health verification failed:', error.message || error);
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(1);
+  }
+
+  const issues = [];
+  if (report.metadataColumnsMissing.length) {
+    issues.push(`Missing metadata columns: ${report.metadataColumnsMissing.join(', ')}`);
+  }
+  if (report.chunkColumnsMissing.length) {
+    issues.push(`Missing chunk columns: ${report.chunkColumnsMissing.join(', ')}`);
+  }
+  if (report.documentsCount <= 0) {
+    issues.push('No documents found in documents_metadata.');
+  }
+  if (report.chunksCount <= 0) {
+    issues.push('No chunks stored in document_chunks.');
+  }
+  if (report.orphanChunks > 0) {
+    issues.push(`Found ${report.orphanChunks} orphan chunk(s).`);
+  }
+  if (!report.schemaVisible) {
+    issues.push('document_chunks.doc_id not visible via PostgREST.');
+  }
+
+  if (issues.length) {
+    console.error('❌ Issues detected:\n - ' + issues.join('\n - '));
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(1);
+  }
+
+  console.log('✅ RAG health looks good');
+  console.log(JSON.stringify(report, null, 2));
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('❌ Unexpected error during health verification:', error.message || error);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/supabase/migrations/20250709120000_fix_rag_schema.sql
+++ b/supabase/migrations/20250709120000_fix_rag_schema.sql
@@ -1,0 +1,208 @@
+/*
+  # Harmonise RAG document schema
+
+  - Ensure documents_metadata contains processing status columns with sane defaults
+  - Align document_chunks to use doc_id as foreign key and enforce referential integrity
+  - Clean up orphaned chunks and guarantee embedding column dimensions
+  - Refresh the match_documents RPC to rely on doc_id and cosine similarity
+  - Trigger a PostgREST schema cache reload so new columns are immediately available
+*/
+
+BEGIN;
+
+-- Required extensions for UUID generation and pgvector
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- documents_metadata required columns
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS processed boolean DEFAULT false;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS processed_at timestamptz;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS needs_ocr boolean DEFAULT false;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS chunk_count integer DEFAULT 0;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS retry_count integer DEFAULT 0;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS last_error text;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS storage_path text;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS mime_type text;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS filename text;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS ready_for_indexing boolean DEFAULT false;
+ALTER TABLE public.documents_metadata
+  ADD COLUMN IF NOT EXISTS last_updated timestamptz DEFAULT now();
+
+-- Ensure sensible defaults and non-null values
+UPDATE public.documents_metadata
+SET
+  processed = COALESCE(processed, false),
+  needs_ocr = COALESCE(needs_ocr, false),
+  chunk_count = COALESCE(chunk_count, 0),
+  retry_count = COALESCE(retry_count, 0),
+  ready_for_indexing = COALESCE(ready_for_indexing, false),
+  last_updated = COALESCE(last_updated, now());
+
+ALTER TABLE public.documents_metadata
+  ALTER COLUMN processed SET DEFAULT false,
+  ALTER COLUMN needs_ocr SET DEFAULT false,
+  ALTER COLUMN chunk_count SET DEFAULT 0,
+  ALTER COLUMN retry_count SET DEFAULT 0,
+  ALTER COLUMN ready_for_indexing SET DEFAULT false,
+  ALTER COLUMN last_updated SET DEFAULT now();
+
+-- Prefer not-null semantics where possible
+ALTER TABLE public.documents_metadata
+  ALTER COLUMN processed SET NOT NULL,
+  ALTER COLUMN needs_ocr SET NOT NULL,
+  ALTER COLUMN chunk_count SET NOT NULL,
+  ALTER COLUMN retry_count SET NOT NULL,
+  ALTER COLUMN ready_for_indexing SET NOT NULL;
+
+-- document_chunks column alignment
+DO
+$$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'document_chunks'
+      AND column_name = 'document_id'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.document_chunks RENAME COLUMN document_id TO doc_id';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.document_chunks
+  ADD COLUMN IF NOT EXISTS doc_id uuid;
+
+-- Ensure doc_id column type is UUID
+DO
+$$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'document_chunks'
+      AND column_name = 'doc_id'
+      AND data_type <> 'uuid'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.document_chunks ALTER COLUMN doc_id TYPE uuid USING doc_id::uuid';
+  END IF;
+END
+$$;
+
+-- Guarantee chunk_index defaults
+ALTER TABLE public.document_chunks
+  ALTER COLUMN chunk_index SET DEFAULT 0;
+UPDATE public.document_chunks SET chunk_index = 0 WHERE chunk_index IS NULL;
+ALTER TABLE public.document_chunks
+  ALTER COLUMN chunk_index SET NOT NULL;
+
+-- Ensure id has a default generator
+ALTER TABLE public.document_chunks
+  ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+-- Ensure embedding column exists and has correct dimension
+ALTER TABLE public.document_chunks
+  ADD COLUMN IF NOT EXISTS embedding vector(1536);
+
+DO
+$$
+DECLARE
+  current_dim integer;
+BEGIN
+  SELECT atttypmod - 4
+    INTO current_dim
+  FROM pg_attribute
+  WHERE attrelid = 'public.document_chunks'::regclass
+    AND attname = 'embedding'
+    AND NOT attisdropped;
+
+  IF current_dim IS NOT NULL AND current_dim <> 1536 THEN
+    EXECUTE 'ALTER TABLE public.document_chunks ALTER COLUMN embedding TYPE vector(1536)';
+  END IF;
+END
+$$;
+
+-- Remove orphaned chunks and enforce FK integrity
+DELETE FROM public.document_chunks dc
+WHERE dc.doc_id IS NULL
+   OR NOT EXISTS (
+     SELECT 1 FROM public.documents_metadata dm WHERE dm.id = dc.doc_id
+   );
+
+ALTER TABLE public.document_chunks
+  ALTER COLUMN doc_id SET NOT NULL;
+
+DO
+$$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.document_chunks'::regclass
+      AND conname = 'document_chunks_doc_id_fkey'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.document_chunks
+      ADD CONSTRAINT document_chunks_doc_id_fkey
+      FOREIGN KEY (doc_id)
+      REFERENCES public.documents_metadata(id)
+      ON DELETE CASCADE';
+  END IF;
+END
+$$;
+
+-- Index for fast lookup / idempotent creation
+CREATE INDEX IF NOT EXISTS document_chunks_doc_id_idx
+  ON public.document_chunks (doc_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS document_chunks_doc_id_chunk_index_key
+  ON public.document_chunks (doc_id, chunk_index);
+
+-- Refresh the vector search RPC to emit doc_id
+CREATE OR REPLACE FUNCTION public.match_documents(
+  query_embedding vector(1536),
+  similarity_threshold double precision DEFAULT 0.7,
+  match_count integer DEFAULT 5
+)
+RETURNS TABLE (
+  doc_id uuid,
+  chunk_index integer,
+  content text,
+  similarity double precision
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    dc.doc_id,
+    dc.chunk_index,
+    dc.content,
+    1 - (dc.embedding <=> query_embedding) AS similarity
+  FROM public.document_chunks dc
+  WHERE dc.embedding IS NOT NULL
+    AND (
+      similarity_threshold IS NULL
+      OR 1 - (dc.embedding <=> query_embedding) >= similarity_threshold
+    )
+  ORDER BY dc.embedding <=> query_embedding
+  LIMIT GREATEST(1, COALESCE(match_count, 5));
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.match_documents(vector(1536), double precision, integer) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.match_documents(vector(1536), double precision, integer) TO service_role;
+
+-- Ask PostgREST to refresh its schema cache so new columns show up immediately
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add an idempotent Supabase migration that harmonises documents_metadata/document_chunks, enforces doc_id integrity and refreshes match_documents
- harden the processing pipeline and extract-text helpers to skip junk files, classify OCR/content errors and consistently use doc_id
- add a repeatable RAG health verification script plus README instructions and npm alias for the end-to-end workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d284bb7bf8832ba4caf4d9e2ee741a