### PR TITLE
Use Supabase admin client for RAG API routes

### DIFF
--- a/pages/api/chat-rag.ts
+++ b/pages/api/chat-rag.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { OpenAI } from 'openai';
-import { supabase } from '../../lib/supabaseClient';
+import { supabaseAdmin } from '../../lib/server/supabaseAdmin';
 import { RAGPipeline } from '../../lib/rag/pipeline';
 import { openaiApiKey } from '../../lib/rag/config';
 
@@ -46,7 +46,7 @@ export default async function handler(
     }
 
     // 1. Create RAG pipeline
-    const pipeline = new RAGPipeline(supabase, openaiApiKey);
+    const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
 
     // 2. Search for relevant documents
     console.log(`🔍 Searching for documents relevant to: "${prompt.substring(0, 50)}..."`);
@@ -113,7 +113,7 @@ ${context}`;
     
     // 8. Log the prompt, context, and response to chat_logs table
     try {
-      await supabase.from('chat_logs').insert({
+      await supabaseAdmin.from('chat_logs').insert({
         prompt,
         context: context || 'No relevant context found',
         response: reply,

--- a/pages/api/chat-with-context.ts
+++ b/pages/api/chat-with-context.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { OpenAI } from 'openai';
-import { supabase } from '../../lib/supabaseClient';
+import { supabaseAdmin } from '../../lib/server/supabaseAdmin';
 import { RAGPipeline } from '../../lib/rag/pipeline';
 import { openaiApiKey } from '../../lib/rag/config';
 
@@ -51,7 +51,7 @@ export default async function handler(
     }
 
     // 1. Create RAG pipeline
-    const pipeline = new RAGPipeline(supabase, openaiApiKey);
+    const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
 
     // 2. Search for relevant documents
     console.log(`🔍 Searching for documents relevant to: "${prompt.substring(0, 50)}..."`);
@@ -133,7 +133,7 @@ ${context}`;
     
     // 8. Log the chat interaction to chat_logs table
     try {
-      await supabase.from('chat_logs').insert({
+      await supabaseAdmin.from('chat_logs').insert({
         prompt: prompt,
         reply: reply, 
         modelUsed: selectedModel,

--- a/pages/api/chat.ts
+++ b/pages/api/chat.ts
@@ -4,7 +4,6 @@ import { supabaseAdmin } from '../../lib/server/supabaseAdmin';
 import { getOrCreateSession } from '../../lib/chat/session';
 import { RAGPipeline } from '../../lib/rag/pipeline';
 import { RAG_CONFIG, openaiApiKey } from '../../lib/rag/config';
-import { createClient } from '@supabase/supabase-js';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
@@ -32,13 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     });
 
     // RAG retrieval
-    // Tip: als RLS het lezen van vector-data blokkeert, vervang dan supabaseUserClient door supabaseAdmin
-    const supabaseUserClient = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    );
-
-    const pipeline = new RAGPipeline(supabaseUserClient, openaiApiKey);
+    const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
     const results = await pipeline.searchSimilarDocuments(message);
 
     // Context opbouwen (optioneel inkorten tot maxResults)

--- a/pages/api/test-rag-pipeline.ts
+++ b/pages/api/test-rag-pipeline.ts
@@ -81,19 +81,19 @@ async function processTestDocument(documentId: string, res: NextApiResponse) {
     }
 
     // Initialize RAG pipeline
-    const pipeline = new RAGPipeline(supabase, openaiApiKey);
+    const pipeline = new RAGPipeline(supabaseAdmin, openaiApiKey);
 
-  // Process the document
-  await pipeline.processDocument(document, {
-    chunkSize: RAG_CONFIG.chunkSize,
-    chunkOverlap: RAG_CONFIG.chunkOverlap
-  });
+    // Process the document
+    await pipeline.processDocument(document, {
+      chunkSize: RAG_CONFIG.chunkSize,
+      chunkOverlap: RAG_CONFIG.chunkOverlap
+    });
 
     // Verify chunks were created
     const { data: chunks, error: chunksError } = await supabaseAdmin
       .from('document_chunks')
       .select('id, chunk_index, content')
-    .eq('doc_id', documentId);
+      .eq('doc_id', documentId);
 
     if (chunksError) {
       throw chunksError;


### PR DESCRIPTION
## Summary
- switch chat-focused API routes to use the Supabase service-role client when constructing the RAG pipeline
- log chat interactions through the admin client so writes succeed under RLS
- align the RAG pipeline test endpoint with the service-role client for document processing

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d2ae0d05c8832b9c52fd785359ef13