### PR TITLE
Open admin dashboard to all users

### DIFF
--- a/components/AdminButton.tsx
+++ b/components/AdminButton.tsx
@@ -1,9 +1,6 @@
 import Link from 'next/link';
 
 export default function AdminButton() {
-  const visible = process.env.NEXT_PUBLIC_PUBLIC_ADMIN === 'true' || process.env.PUBLIC_ADMIN === 'true';
-  if (!visible) return null;
-
   return (
     <Link
       href="/admin"

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -4,22 +4,16 @@ type CountRes = { total_docs: number; processed_docs: number; chunks: number; ne
 type ChatStat = { messages: number; sessions: number; last_message_at: string | null; };
 
 export default function AdminHome() {
-  const [allowed, setAllowed] = useState(false);
   const [counts, setCounts] = useState<CountRes | null>(null);
   const [chat, setChat] = useState<ChatStat | null>(null);
 
   useEffect(() => {
-    const ok = process.env.NEXT_PUBLIC_PUBLIC_ADMIN === 'true' || process.env.PUBLIC_ADMIN === 'true';
-    setAllowed(!!ok);
-
     (async () => {
       const a = await fetch('/api/admin/stats').then(r => r.json()).catch(() => null);
       setCounts(a?.rag || null);
       setChat(a?.chat || null);
     })();
   }, []);
-
-  if (!allowed) return <div className="p-6">403 — Admin tijdelijk uitgeschakeld</div>;
 
   return (
     <div className="max-w-5xl mx-auto p-6">

--- a/pages/api/admin/health.ts
+++ b/pages/api/admin/health.ts
@@ -3,14 +3,7 @@ import { OpenAI } from 'openai';
 import { RAG_CONFIG } from '../../../lib/rag/config';
 import { supabaseAdmin } from '../../../lib/server/supabaseAdmin';
 
-const isPublicAdminEnabled = () =>
-  process.env.NEXT_PUBLIC_PUBLIC_ADMIN === 'true' || process.env.PUBLIC_ADMIN === 'true';
-
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (!isPublicAdminEnabled()) {
-    return res.status(403).json({ error: 'disabled' });
-  }
-
   try {
     const [documentsResp, chunksResp] = await Promise.all([
       supabaseAdmin.from('documents_metadata').select('id', { count: 'exact', head: true }),

--- a/pages/api/admin/stats.ts
+++ b/pages/api/admin/stats.ts
@@ -9,16 +9,6 @@ type ChatAgg = {
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    // toggles: maak admin endpoint publiek
-    const publicAdmin =
-      process.env.NEXT_PUBLIC_PUBLIC_ADMIN === 'true' ||
-      process.env.PUBLIC_ADMIN === 'true';
-
-    if (!publicAdmin) {
-      res.status(403).json({ error: 'disabled' });
-      return;
-    }
-
     // --- RAG stats ---
     const docsRpcPromise = (async () => {
       try {


### PR DESCRIPTION
## Summary
- remove the feature flag that hid the admin dashboard UI and API endpoints
- always show the admin shortcut button so everyone can reach the dashboard

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68da5e5f7c2c832ba86cc9aea715c87d